### PR TITLE
Fix category_tree li ul issue

### DIFF
--- a/includes/classes/category_tree.php
+++ b/includes/classes/category_tree.php
@@ -88,7 +88,7 @@
             $result .= $this->parent_end_string;
           }
 
-          $result .= $this->child_end_string;
+
 
           if ( isset($this->_data[$category_id]) && (($this->max_level == '0') || ($this->max_level > $level+1)) ) {
             if ( $this->follow_cpath === true ) {
@@ -99,6 +99,8 @@
               $result .= $this->_buildBranch($category_id, $level+1);
             }
           }
+          
+          $result .= $this->child_end_string;          
         }
       }
 


### PR DESCRIPTION
Fixed the default behavior for expanding child's from parents:
Currently <li>Hardware</li> <ul>the children</ul>

With the fix:

<li>Hardware <ul>the children</ul></li>
