### PR TITLE
php checkdate wrong parameters order

### DIFF
--- a/create_account.php
+++ b/create_account.php
@@ -77,7 +77,7 @@
     }
 
     if (ACCOUNT_DOB == 'true') {
-      if ((strlen($dob) < ENTRY_DOB_MIN_LENGTH) || (!empty($dob) && (!is_numeric(tep_date_raw($dob)) || !@checkdate(substr(tep_date_raw($dob), 4, 2), substr(tep_date_raw($dob), 6, 2), substr(tep_date_raw($dob), 0, 4))))) {
+      if ((strlen($dob) < ENTRY_DOB_MIN_LENGTH) || (!empty($dob) && (!is_numeric(tep_date_raw($dob)) || !@checkdate(substr(tep_date_raw($dob), 6, 2), substr(tep_date_raw($dob), 4, 2), substr(tep_date_raw($dob), 0, 4))))) {
         $error = true;
 
         $messageStack->add('create_account', ENTRY_DATE_OF_BIRTH_ERROR);


### PR DESCRIPTION
The php checkdate functions parameters were passed in wrong order. Passed "dd" as first parameter and "mm" as second which is wrong according to http://php.net/manual/en/function.checkdate.php and made visitors cannot create account.
