### PR TITLE
Duplicate attribute class fixed

### DIFF
--- a/includes/functions/html_output.php
+++ b/includes/functions/html_output.php
@@ -424,7 +424,7 @@
     $search_link = '';
     $search_link .= tep_draw_form('quick_find', tep_href_link(FILENAME_ADVANCED_SEARCH_RESULT, '', $request_type, false), 'get', 'class="navbar-form"');
     $search_link .= '    <div class="input-group">' .
-                            tep_draw_input_field('keywords', '', 'required class="form-control" placeholder="' . TEXT_SEARCH_PLACEHOLDER . '"') .
+                            tep_draw_input_field('keywords', '', 'required placeholder="' . TEXT_SEARCH_PLACEHOLDER . '"') .
                      '        <span class="input-group-btn"><button type="submit" class="btn ' . $btnclass .'"><i class="glyphicon glyphicon-search"></i></button></span>' .
                      '    </div>';
     if (tep_not_null($description) && ($description === true)) {


### PR DESCRIPTION
Removed class class="form-control" causing duplicate class and so no validation.

tep_draw_input_field() function by default adds class="form-control" so no need to put it again
