### PR TITLE
icon fix to custom.css for selects

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -3,7 +3,14 @@
 
 
 /* Historical osCommerce ---------------------------------------------------- */
+/* GlyphIcon positioning for select menus */
+select ~ .form-control-feedback {
+ margin-right: 15px;
+}
 
+select[multiple] ~ .form-control-feedback {
+  margin-right: 0;
+}
 .buttonSet {
   margin-top: 10px;
   margin-bottom: 10px;


### PR DESCRIPTION
This fixes the not-click-able selection, when use (glyph) icon, to show it is required.
