### PR TITLE
changes to template structure

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -270,26 +270,26 @@ p.lead del {
 }
 
 /* Footer ------------------------------------------------------------------- */
-.footer {
+#footer {
   background: #eee;
   border-top: 2px solid #ddd;
 }
 
-.footer .footerbox {
+#footer .footerbox {
   padding: 10px 10px 0px 10px;
 }
 
-.footer-extra {
+#footer-extra {
   background: #111;
   color: silver;
   line-height: 3;
 }
 
-.footer-extra A {
+#footer-extra A {
   color: silver;
 }
 
-.footer h2 {
+#footer h2 {
   padding: 0;
   margin: 0;
   font-size: 1em;

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -12,22 +12,12 @@
 
 ?>
 
-</div>
-
-<footer>
-  <div class="footer">
-    <div class="container-fluid">
-      <div class="row">
-        <?php echo $oscTemplate->getContent('footer'); ?>
-      </div>
+  <footer id="modular-footer" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
+    <div id="footer" class="row">
+      <?php echo $oscTemplate->getContent('footer'); ?>
     </div>
-  </div>
-  <div class="footer-extra">
-    <div class="container-fluid">
-      <div class="row">
-        <?php echo $oscTemplate->getContent('footer_suffix'); ?>
-      </div>
+      
+    <div id="footer-extra" class="row">
+      <?php echo $oscTemplate->getContent('footer_suffix'); ?>
     </div>
-  </div>
-</footer>
-
+  </footer>

--- a/includes/header.php
+++ b/includes/header.php
@@ -10,41 +10,17 @@
   Released under the GNU General Public License
 */
 
-  if ($messageStack->size('header') > 0) {
-    echo '<div class="col-md-12">' . $messageStack->output('header') . '</div>';
-  }
+  if ($messageStack->size('header') > 0) { 
 ?>
-
-<div class="modular-header">
-  <?php echo $oscTemplate->getContent('header'); ?>
-</div>
-
-<div class="clearfix"></div>
-
-<div class="body-sans-header clearfix">
-
-<?php
-  if (isset($HTTP_GET_VARS['error_message']) && tep_not_null($HTTP_GET_VARS['error_message'])) {
-?>
-<div class="clearfix"></div>
-<div class="col-xs-12">
-  <div class="alert alert-danger">
-    <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
-    <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['error_message']))); ?>
+  <div class="row">
+    <div class="col-sm-12"><?php echo $messageStack->output('header'); ?></div>
   </div>
-</div>
 <?php
   }
+?>
 
-  if (isset($HTTP_GET_VARS['info_message']) && tep_not_null($HTTP_GET_VARS['info_message'])) {
-?>
-<div class="clearfix"></div>
-<div class="col-xs-12">
-  <div class="alert alert-info">
-    <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
-    <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['info_message']))); ?>
-  </div>
-</div>
-<?php
-  }
-?>
+  <header id="modular-header" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
+    <div id="header" class="row">
+      <?php echo $oscTemplate->getContent('header'); ?>
+    </div>
+  </header>

--- a/includes/header.php
+++ b/includes/header.php
@@ -11,11 +11,7 @@
 */
 
   if ($messageStack->size('header') > 0) { 
-?>
-  <div class="row">
-    <div class="col-sm-12"><?php echo $messageStack->output('header'); ?></div>
-  </div>
-<?php
+     echo $messageStack->output('header'); 
   }
 ?>
 

--- a/includes/template_bottom.php
+++ b/includes/template_bottom.php
@@ -39,15 +39,7 @@
 
   </section> <!-- bodyWrapper //-->
 
-  <footer id="modular-footer" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
-    <div id="footer" class="row">
-      <?php echo $oscTemplate->getContent('footer'); ?>
-    </div>
-      
-    <div id="footer-extra" class="row">
-      <?php echo $oscTemplate->getContent('footer_suffix'); ?>
-    </div>
-  </footer>
+  <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
 
   <script src="ext/bootstrap/js/bootstrap.min.js"></script>
   <?php echo $oscTemplate->getBlocks('footer_scripts'); ?>

--- a/includes/template_bottom.php
+++ b/includes/template_bottom.php
@@ -17,9 +17,9 @@
   if ($oscTemplate->hasBlocks('boxes_column_left')) {
 ?>
 
-      <aside id="columnLeft" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>  col-md-pull-<?php echo $oscTemplate->getGridContentWidth(); ?>">
+      <div id="columnLeft" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>  col-md-pull-<?php echo $oscTemplate->getGridContentWidth(); ?>">
         <?php echo $oscTemplate->getBlocks('boxes_column_left'); ?>
-      </aside>
+      </div>
 
 <?php
   }
@@ -27,9 +27,9 @@
   if ($oscTemplate->hasBlocks('boxes_column_right')) {
 ?>
 
-      <aside id="columnRight" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>">
+      <div id="columnRight" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>">
         <?php echo $oscTemplate->getBlocks('boxes_column_right'); ?>
-      </aside>
+      </div>
 
 <?php
   }

--- a/includes/template_bottom.php
+++ b/includes/template_bottom.php
@@ -17,9 +17,9 @@
   if ($oscTemplate->hasBlocks('boxes_column_left')) {
 ?>
 
-      <div id="columnLeft" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>  col-md-pull-<?php echo $oscTemplate->getGridContentWidth(); ?>">
+      <aside id="columnLeft" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>  col-md-pull-<?php echo $oscTemplate->getGridContentWidth(); ?>">
         <?php echo $oscTemplate->getBlocks('boxes_column_left'); ?>
-      </div>
+      </aside>
 
 <?php
   }
@@ -27,9 +27,9 @@
   if ($oscTemplate->hasBlocks('boxes_column_right')) {
 ?>
 
-      <div id="columnRight" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>">
+      <aside id="columnRight" class="col-md-<?php echo $oscTemplate->getGridColumnWidth(); ?>">
         <?php echo $oscTemplate->getBlocks('boxes_column_right'); ?>
-      </div>
+      </aside>
 
 <?php
   }
@@ -37,12 +37,20 @@
 
     </div> <!-- row -->
 
-  </div> <!-- bodyWrapper //-->
+  </section> <!-- bodyWrapper //-->
 
-  <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
+  <footer id="modular-footer" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
+    <div id="footer" class="row">
+      <?php echo $oscTemplate->getContent('footer'); ?>
+    </div>
+      
+    <div id="footer-extra" class="row">
+      <?php echo $oscTemplate->getContent('footer_suffix'); ?>
+    </div>
+  </footer>
 
-<script src="ext/bootstrap/js/bootstrap.min.js"></script>
-<?php echo $oscTemplate->getBlocks('footer_scripts'); ?>
+  <script src="ext/bootstrap/js/bootstrap.min.js"></script>
+  <?php echo $oscTemplate->getBlocks('footer_scripts'); ?>
 
 </body>
 </html>

--- a/includes/template_top.php
+++ b/includes/template_top.php
@@ -60,26 +60,20 @@
 <?php
   if (isset($HTTP_GET_VARS['error_message']) && tep_not_null($HTTP_GET_VARS['error_message'])) {
 ?>
-        <div class="row">
-          <div class="col-xs-12">
-            <div class="alert alert-danger">
-              <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
-              <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['error_message']))); ?>
-            </div>
-          </div>
+
+        <div class="alert alert-danger">
+          <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
+          <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['error_message']))); ?>
         </div>
 <?php
   }
 
   if (isset($HTTP_GET_VARS['info_message']) && tep_not_null($HTTP_GET_VARS['info_message'])) {
 ?>
-        <div class="row">
-          <div class="col-xs-12">
-            <div class="alert alert-info">
-              <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
-              <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['info_message']))); ?>
-            </div>
-          </div>
+
+        <div class="alert alert-info">
+          <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
+          <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['info_message']))); ?>
         </div>
 <?php
   }

--- a/includes/template_top.php
+++ b/includes/template_top.php
@@ -50,9 +50,51 @@
 
   <?php echo $oscTemplate->getContent('navigation'); ?>
   
-  <div id="bodyWrapper" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
+<?php
+  if ($messageStack->size('header') > 0) { 
+?>
+  <div class="row">
+    <div class="col-sm-12"><?php echo $messageStack->output('header'); ?></div>
+  </div>
+<?php
+  }
+?>
+
+  <header id="modular-header" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
+    <div id="header" class="row">
+      <?php echo $oscTemplate->getContent('header'); ?>
+    </div>
+  </header>
+   
+  <section id="bodyWrapper" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
     <div class="row">
 
-      <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
-
       <div id="bodyContent" class="col-md-<?php echo $oscTemplate->getGridContentWidth(); ?> <?php echo ($oscTemplate->hasBlocks('boxes_column_left') ? 'col-md-push-' . $oscTemplate->getGridColumnWidth() : ''); ?>">
+      
+<?php
+  if (isset($HTTP_GET_VARS['error_message']) && tep_not_null($HTTP_GET_VARS['error_message'])) {
+?>
+        <div class="row">
+          <div class="col-xs-12">
+            <div class="alert alert-danger">
+              <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
+              <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['error_message']))); ?>
+            </div>
+          </div>
+        </div>
+<?php
+  }
+
+  if (isset($HTTP_GET_VARS['info_message']) && tep_not_null($HTTP_GET_VARS['info_message'])) {
+?>
+        <div class="row">
+          <div class="col-xs-12">
+            <div class="alert alert-info">
+              <a href="#" class="close glyphicon glyphicon-remove" data-dismiss="alert"></a>
+              <?php echo htmlspecialchars(stripslashes(urldecode($HTTP_GET_VARS['info_message']))); ?>
+            </div>
+          </div>
+        </div>
+<?php
+  }
+?>

--- a/includes/template_top.php
+++ b/includes/template_top.php
@@ -49,22 +49,8 @@
 <body>
 
   <?php echo $oscTemplate->getContent('navigation'); ?>
-  
-<?php
-  if ($messageStack->size('header') > 0) { 
-?>
-  <div class="row">
-    <div class="col-sm-12"><?php echo $messageStack->output('header'); ?></div>
-  </div>
-<?php
-  }
-?>
 
-  <header id="modular-header" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
-    <div id="header" class="row">
-      <?php echo $oscTemplate->getContent('header'); ?>
-    </div>
-  </header>
+  <?php require(DIR_WS_INCLUDES . 'header.php'); ?>
    
   <section id="bodyWrapper" class="<?php echo BOOTSTRAP_CONTAINER; ?>">
     <div class="row">


### PR DESCRIPTION
changes to template structure to wrap each section of site for more control design wise.
Move info and error messages down into #bodyContent for better view and to avoid breaking up under the header.

//EDIT:
header.php and footer.php moved back after previous commit, leaving backwards compatibility in place. 
//EO-EDIT

HTML5 markup, we already are loading html5shiv so may as well use them, or can be covered back to standard DIV's.