### PR TITLE
Contect modules

### DIFF
--- a/includes/languages/english.php
+++ b/includes/languages/english.php
@@ -276,3 +276,6 @@ define('PRODUCT_SUBSCRIBED', '%s has been added to your Notification List');
 define('PRODUCT_UNSUBSCRIBED', '%s has been removed from your Notification List');
 define('PRODUCT_ADDED', '%s has been added to your Cart');
 define('PRODUCT_REMOVED', '%s has been removed from your Cart');
+
+// bootstrap helper
+define('MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION', '<p>Content Width can be 12 or less per column per row.</p><p>12/12 = 100% width, 6/12 = 50% width, 4/12 = 33% width.</p><p>Total of all columns in any one row must equal 12 (eg:  3 boxes of 4 columns each, 1 box of 12 columns and so on).</p>');

--- a/includes/modules/content/footer/cm_footer_account.php
+++ b/includes/modules/content/footer/cm_footer_account.php
@@ -24,6 +24,7 @@
 
       $this->title = MODULE_CONTENT_FOOTER_ACCOUNT_TITLE;
       $this->description = MODULE_CONTENT_FOOTER_ACCOUNT_DESCRIPTION;
+      $this->description .= '<div class="secWarning">' . MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION . '</div>';
 
       if ( defined('MODULE_CONTENT_FOOTER_ACCOUNT_STATUS') ) {
         $this->sort_order = MODULE_CONTENT_FOOTER_ACCOUNT_SORT_ORDER;

--- a/includes/modules/content/footer/cm_footer_contact_us.php
+++ b/includes/modules/content/footer/cm_footer_contact_us.php
@@ -24,6 +24,7 @@
 
       $this->title = MODULE_CONTENT_FOOTER_CONTACT_US_TITLE;
       $this->description = MODULE_CONTENT_FOOTER_CONTACT_US_DESCRIPTION;
+      $this->description .= '<div class="secWarning">' . MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION . '</div>';
 
       if ( defined('MODULE_CONTENT_FOOTER_CONTACT_US_STATUS') ) {
         $this->sort_order = MODULE_CONTENT_FOOTER_CONTACT_US_SORT_ORDER;

--- a/includes/modules/content/footer/cm_footer_information_links.php
+++ b/includes/modules/content/footer/cm_footer_information_links.php
@@ -24,6 +24,7 @@
 
       $this->title = MODULE_CONTENT_FOOTER_INFORMATION_TITLE;
       $this->description = MODULE_CONTENT_FOOTER_INFORMATION_DESCRIPTION;
+      $this->description .= '<div class="secWarning">' . MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION . '</div>';
 
       if ( defined('MODULE_CONTENT_FOOTER_INFORMATION_STATUS') ) {
         $this->sort_order = MODULE_CONTENT_FOOTER_INFORMATION_SORT_ORDER;

--- a/includes/modules/content/footer/cm_footer_text.php
+++ b/includes/modules/content/footer/cm_footer_text.php
@@ -24,6 +24,7 @@
 
       $this->title = MODULE_CONTENT_FOOTER_TEXT_TITLE;
       $this->description = MODULE_CONTENT_FOOTER_TEXT_DESCRIPTION;
+      $this->description .= '<div class="secWarning">' . MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION . '</div>';
 
       if ( defined('MODULE_CONTENT_FOOTER_TEXT_STATUS') ) {
         $this->sort_order = MODULE_CONTENT_FOOTER_TEXT_SORT_ORDER;

--- a/includes/modules/content/footer_suffix/cm_footer_extra_copyright.php
+++ b/includes/modules/content/footer_suffix/cm_footer_extra_copyright.php
@@ -24,6 +24,7 @@
 
       $this->title = MODULE_CONTENT_FOOTER_EXTRA_COPYRIGHT_TITLE;
       $this->description = MODULE_CONTENT_FOOTER_EXTRA_COPYRIGHT_DESCRIPTION;
+      $this->description .= '<div class="secWarning">' . MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION . '</div>';
 
       if ( defined('MODULE_CONTENT_FOOTER_EXTRA_COPYRIGHT_STATUS') ) {
         $this->sort_order = MODULE_CONTENT_FOOTER_EXTRA_COPYRIGHT_SORT_ORDER;

--- a/includes/modules/content/footer_suffix/cm_footer_extra_icons.php
+++ b/includes/modules/content/footer_suffix/cm_footer_extra_icons.php
@@ -24,6 +24,7 @@
 
       $this->title = MODULE_CONTENT_FOOTER_EXTRA_ICONS_TITLE;
       $this->description = MODULE_CONTENT_FOOTER_EXTRA_ICONS_DESCRIPTION;
+      $this->description .= '<div class="secWarning">' . MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION . '</div>';
 
       if ( defined('MODULE_CONTENT_FOOTER_EXTRA_ICONS_STATUS') ) {
         $this->sort_order = MODULE_CONTENT_FOOTER_EXTRA_ICONS_SORT_ORDER;

--- a/includes/modules/content/header/cm_header_search.php
+++ b/includes/modules/content/header/cm_header_search.php
@@ -24,6 +24,7 @@
 
       $this->title = MODULE_CONTENT_HEADER_SEARCH_TITLE;
       $this->description = MODULE_CONTENT_HEADER_SEARCH_DESCRIPTION;
+      $this->description .= '<div class="secWarning">' . MODULE_CONTENT_BOOTSTRAP_ROW_DESCRIPTION . '</div>';
 
       if ( defined('MODULE_CONTENT_HEADER_SEARCH_STATUS') ) {
         $this->sort_order = MODULE_CONTENT_HEADER_SEARCH_SORT_ORDER;


### PR DESCRIPTION
Makes the Admin Content Module management more consistent by providing the Content Width description to those modules that contain the field.  Also addresses Undefined Constants on the catalog side when any of the footer or header modules are installed (this fix can be improved on depending on how the core team would like to address).

  Issue was discussed on forum http://forums.oscommerce.com/topic/407945-undefined-constant-in-cm-header-logophp/#entry1731084 .
