### PR TITLE
Update breadcrumb.php

### DIFF
--- a/includes/classes/breadcrumb.php
+++ b/includes/classes/breadcrumb.php
@@ -26,20 +26,18 @@
     }
 
     function trail($separator = NULL) {
-      $pos = 1;
-      $trail_string = '<ol  itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb">';
+      $trail_string = '<ul itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb">' . PHP_EOL;
 
       for ($i=0, $n=sizeof($this->_trail); $i<$n; $i++) {
         if (isset($this->_trail[$i]['link']) && tep_not_null($this->_trail[$i]['link'])) {
-          $trail_string .= '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="' . $this->_trail[$i]['link'] . '" itemprop="item"><span itemprop="name">' . $this->_trail[$i]['title'] . '</span></a>';
+          $trail_string .= '  <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="' . $this->_trail[$i]['link'] . '" itemprop="item"><span itemprop="name">' . $this->_trail[$i]['title'] . '</span></a>';
         } else {
-          $trail_string .= '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">' . $this->_trail[$i]['title'] . '</span>';
+          $trail_string .= '  <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">' . $this->_trail[$i]['title'] . '</span>';
         }
-        $trail_string .= '<meta itemprop="position" content="' . (int)$pos . '" /></li>' . PHP_EOL;
-        $pos++;
+        $trail_string .= '<meta itemprop="position" content="' . ($i+1) . '" /></li>' . PHP_EOL;
       }      
   
-      $trail_string .= '</ol>';
+      $trail_string .= '</ul>' . PHP_EOL;
 
       return $trail_string;
     }


### PR DESCRIPTION
Changed ol to ul.
Remove $pos variable as it no needed since we can use $i for its purpose.
Added 2 space chars in front of <li so the generated source code to be more readable.
Added  . PHP_EOL so the generated source code to be more readable.

Note: the $separator paramater can also be removed but it also has to be removed by the parent breadcumb.php where the 
<?php echo $breadcrumb->trail(' &raquo; '); ?> 
gets called