### PR TITLE
Update application_top.php

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -325,7 +325,7 @@
       $parameters = array('action', 'cPath', 'products_id', 'pid');
     } else {
       $goto = $PHP_SELF;
-      if ($HTTP_GET_VARS['action'] == 'buy_now') {
+      if ($HTTP_GET_VARS['action'] == 'buy_now' || $HTTP_GET_VARS['action'] == 'remove_product') {
         $parameters = array('action', 'pid', 'products_id');
       } else {
         $parameters = array('action', 'pid');


### PR DESCRIPTION
There is no need to return the products_id value after we remove a product from cart.
As you can see after I removed a product from the cart the redirect url contains the products_id.

The alert message with the name of the product that has been removed, is added in the messages stact using the add_session.

A question to osc devs. Is there another way to remove product from the cart apart from the standard x button in the shopping_cart.php page?

![screenshot from 2015-10-26 23 58 24](https://cloud.githubusercontent.com/assets/518451/10743773/f72c8998-7c3d-11e5-8d0b-722d1d4c0d65.png)
