### PR TITLE
Update product_info.php

### DIFF
--- a/product_info.php
+++ b/product_info.php
@@ -71,7 +71,7 @@
 <div itemscope itemtype="http://schema.org/Product">
 
 <div class="page-header">
-  <h1 class="pull-right" itemprop="offers" itemscope itemtype="http://schema.org/Offer"><?php echo $products_price; ?></h1>
+  <h2 class="pull-right" itemprop="offers" itemscope itemtype="http://schema.org/Offer"><?php echo $products_price; ?></h2>
   <h1><?php echo $products_name; ?></h1>
 </div>
 


### PR DESCRIPTION
There should only be one H1 tag per page.  While looking at optimizing my site this was flagged.  So, changing the price to H2 solves this.  From what I've read it is correct to only have one H1 tag.