### PR TITLE
Modular Navigation Bar

### DIFF
--- a/admin/includes/languages/english/modules/cfg_modules/cfgm_navbar_modules.php
+++ b/admin/includes/languages/english/modules/cfg_modules/cfgm_navbar_modules.php
@@ -1,0 +1,13 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+define('MODULE_CFG_MODULE_CONTENT_NAVBAR_TITLE', 'Navbar Modules');

--- a/admin/includes/modules/cfg_modules/cfgm_navbar_modules.php
+++ b/admin/includes/modules/cfg_modules/cfgm_navbar_modules.php
@@ -1,0 +1,25 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class cfgm_navbar_modules {
+    var $code = 'navbar_modules';
+    var $directory;
+    var $language_directory = DIR_FS_CATALOG_LANGUAGES;
+    var $key = 'MODULE_CONTENT_NAVBAR_INSTALLED';
+    var $title;
+    var $template_integration = false;
+
+    function cfgm_navbar_modules() {
+      $this->directory = DIR_FS_CATALOG_MODULES . 'navbar_modules/';
+      $this->title = MODULE_CFG_MODULE_CONTENT_NAVBAR_TITLE;
+    }
+  }

--- a/includes/languages/english/modules/content/navigation/cm_navbar.php
+++ b/includes/languages/english/modules/content/navigation/cm_navbar.php
@@ -5,36 +5,11 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2016 osCommerce
 
   Released under the GNU General Public License
 */
 
   define('MODULE_CONTENT_NAVBAR_TITLE', 'Navigation Bar');
-  define('MODULE_CONTENT_NAVBAR_DESCRIPTION', 'Show the Navigation Bar on your site.');
+  define('MODULE_CONTENT_NAVBAR_DESCRIPTION', 'Show the Navigation Bar on your site. <div class="secWarning">This module has a number of Sub Modules which must also be installed.<br><br>Admin > Modules > Navbar Modules</div>');
   
-  //header titles
-  define('HEADER_CART_CONTENTS', '<i class="fa fa-shopping-cart"></i> %s item(s) <span class="caret"></span>');
-  define('HEADER_CART_NO_CONTENTS', '<i class="fa fa-shopping-cart"></i> 0 items');
-  define('HEADER_ACCOUNT_LOGGED_OUT', '<i class="fa fa-user"></i><span class="hidden-sm"> My Account</span> <span class="caret"></span>');
-  define('HEADER_ACCOUNT_LOGGED_IN', '<i class="fa fa-user"></i> %s <span class="caret"></span>');
-  define('HEADER_SITE_SETTINGS', '<i class="fa fa-cog"></i><span class="hidden-sm"> Site Settings</span> <span class="caret"></span>');
-  define('HEADER_TOGGLE_NAV', 'Toggle Navigation');
-  define('HEADER_HOME', '<i class="fa fa-home"></i><span class="hidden-sm"> Home</span>');
-  define('HEADER_WHATS_NEW', '<i class="fa fa-certificate"></i><span class="hidden-sm">  New Products</span>');
-  define('HEADER_SPECIALS', '<i class="fa fa-fire"></i><span class="hidden-sm"> Special Offers</span>');
-  define('HEADER_REVIEWS', '<i class="fa fa-comment"></i><span class="hidden-sm"> Reviews</span>');
-  // header dropdowns
-  define('HEADER_ACCOUNT_LOGIN', '<i class="fa fa-sign-in"></i> Log In');
-  define('HEADER_ACCOUNT_LOGOFF', '<i class="fa fa-sign-out"></i> Log Off');
-  define('HEADER_ACCOUNT', 'My Account');
-  define('HEADER_ACCOUNT_HISTORY', 'My Orders');
-  define('HEADER_ACCOUNT_EDIT', 'My Details');
-  define('HEADER_ACCOUNT_ADDRESS_BOOK', 'My Address Book');
-  define('HEADER_ACCOUNT_PASSWORD', 'My Password');
-  define('HEADER_ACCOUNT_REGISTER', '<i class="fa fa-pencil"></i> Register');
-  define('HEADER_CART_HAS_CONTENTS', '%s item(s), %s');
-  define('HEADER_CART_VIEW_CART', 'View Cart');
-  define('HEADER_CART_CHECKOUT', '<i class="fa fa-angle-right"></i> Checkout');
-  define('USER_LOCALIZATION', '<abbr title="Selected Language">L:</abbr> %s <abbr title="Selected Currency">C:</abbr> %s');
-

--- a/includes/languages/english/modules/navbar_modules/nb_account.php
+++ b/includes/languages/english/modules/navbar_modules/nb_account.php
@@ -1,0 +1,27 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce 
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_ACCOUNT_TITLE', 'Account');
+  define('MODULE_NAVBAR_ACCOUNT_DESCRIPTION', 'Show Customer Account Actions in Navbar.');
+  
+  define('MODULE_NAVBAR_ACCOUNT_LOGGED_OUT', '<i class="fa fa-user"></i><span class="hidden-sm"> My Account</span> <span class="caret"></span>');
+  define('MODULE_NAVBAR_ACCOUNT_LOGGED_IN', '<i class="fa fa-user"></i> %s <span class="caret"></span>');
+  define('MODULE_NAVBAR_ACCOUNT_LOGIN', '<i class="fa fa-sign-in"></i> Log In');
+  define('MODULE_NAVBAR_ACCOUNT_LOGOFF', '<i class="fa fa-sign-out"></i> Log Off');
+  define('MODULE_NAVBAR_ACCOUNT', 'My Account');
+  define('MODULE_NAVBAR_ACCOUNT_HISTORY', 'My Orders');
+  define('MODULE_NAVBAR_ACCOUNT_EDIT', 'My Details');
+  define('MODULE_NAVBAR_ACCOUNT_ADDRESS_BOOK', 'My Address Book');
+  define('MODULE_NAVBAR_ACCOUNT_PASSWORD', 'My Password');
+  define('MODULE_NAVBAR_ACCOUNT_REGISTER', '<i class="fa fa-pencil"></i> Register');
+
+  

--- a/includes/languages/english/modules/navbar_modules/nb_brand.php
+++ b/includes/languages/english/modules/navbar_modules/nb_brand.php
@@ -1,0 +1,17 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions 
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_BRAND_TITLE', 'Brand');
+  define('MODULE_NAVBAR_BRAND_DESCRIPTION', 'Show Brand in Navbar.  <div class="secWarning">This can be a simple link or something more complicated such as an image.<br><br>For more details about using an image, see <a target="_blank" href="http://getbootstrap.com/components/#navbar-brand-image"><u>#navbar-brand-image</u></a></div>');
+  
+  define('MODULE_NAVBAR_BRAND_PUBLIC_TEXT', '<a class="navbar-brand" href="' . tep_href_link('index.php') . '">' . STORE_NAME . '</a>');
+  

--- a/includes/languages/english/modules/navbar_modules/nb_currencies.php
+++ b/includes/languages/english/modules/navbar_modules/nb_currencies.php
@@ -1,0 +1,16 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions 
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_CURRENCIES_TITLE', 'Currencies');
+  define('MODULE_NAVBAR_CURRENCIES_DESCRIPTION', 'Show Currencies in Navbar. <div class="secWarning">If you have just one Currency in your shop, there is no point installing this module.</div>');
+  
+  define('MODULE_NAVBAR_CURRENCIES_SELECTED_CURRENCY', '<abbr title="Selected Currency">C:</abbr> %s <span class="caret"></span>');

--- a/includes/languages/english/modules/navbar_modules/nb_hamburger_button.php
+++ b/includes/languages/english/modules/navbar_modules/nb_hamburger_button.php
@@ -1,0 +1,18 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_HAMBURGER_BUTTON_TITLE', 'Hamburger Button');
+  define('MODULE_NAVBAR_HAMBURGER_BUTTON_DESCRIPTION', 'Show Hamburger Button in Navbar.  <div class="secWarning">This is a special button that shows when the viewport is small.<br><br>It opens and closes the Main Navbar Menu. You <strong>MUST</strong> install this.</div>');
+  
+  define('MODULE_NAVBAR_HAMBURGER_BUTTON_PUBLIC_SCREENREADER_TEXT', '<span class="sr-only">Toggle Navigation</span>');
+  define('MODULE_NAVBAR_HAMBURGER_BUTTON_PUBLIC_BUTTON_TEXT', '<span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span>');
+  

--- a/includes/languages/english/modules/navbar_modules/nb_home.php
+++ b/includes/languages/english/modules/navbar_modules/nb_home.php
@@ -1,0 +1,17 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_HOME_TITLE', 'Home');
+  define('MODULE_NAVBAR_HOME_DESCRIPTION', 'Show Home Link in Navbar. <div class="secWarning">If you wish to have a Home button permanently displayed (even when the rest of the Menu is collapsed, eg in XS viewport) you could use the Brand module instead.</div>');
+  
+  define('MODULE_NAVBAR_HOME_PUBLIC_TEXT', '<li><a href="' . tep_href_link('index.php') . '"><i class="fa fa-home"></i><span class="hidden-sm"> Home</span></a></li>');
+  

--- a/includes/languages/english/modules/navbar_modules/nb_languages.php
+++ b/includes/languages/english/modules/navbar_modules/nb_languages.php
@@ -1,0 +1,16 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions 
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_LANGUAGES_TITLE', 'Languages');
+  define('MODULE_NAVBAR_LANGUAGES_DESCRIPTION', 'Show Languages in Navbar. <div class="secWarning">If you have just one Language in your shop, there is no point installing this module.</div>');
+  
+  define('MODULE_NAVBAR_LANGUAGES_SELECTED_LANGUAGE', '<abbr title="Selected Language">L:</abbr> English <span class="caret"></span>');

--- a/includes/languages/english/modules/navbar_modules/nb_new_products.php
+++ b/includes/languages/english/modules/navbar_modules/nb_new_products.php
@@ -1,0 +1,17 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License 
+*/
+
+  define('MODULE_NAVBAR_NEW_PRODUCTS_TITLE', 'New Products');
+  define('MODULE_NAVBAR_NEW_PRODUCTS_DESCRIPTION', 'Show New Products Link in Navbar.');
+  
+  define('MODULE_NAVBAR_NEW_PRODUCTS_PUBLIC_TEXT', '<li><a href="' . tep_href_link('products_new.php') . '"><i class="fa fa-certificate"></i><span class="hidden-sm">  New Products</span></a></li>');
+  

--- a/includes/languages/english/modules/navbar_modules/nb_reviews.php
+++ b/includes/languages/english/modules/navbar_modules/nb_reviews.php
@@ -1,0 +1,17 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com 
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_REVIEWS_TITLE', 'Reviews'); 
+  define('MODULE_NAVBAR_REVIEWS_DESCRIPTION', 'Show Reviews Link in Navbar.');
+  
+  define('MODULE_NAVBAR_REVIEWS_PUBLIC_TEXT', '<li><a href="' . tep_href_link('reviews.php') . '"><i class="fa fa-comment"></i><span class="hidden-sm"> Reviews</span></a></li>');
+  

--- a/includes/languages/english/modules/navbar_modules/nb_shopping_cart.php
+++ b/includes/languages/english/modules/navbar_modules/nb_shopping_cart.php
@@ -1,0 +1,23 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com 
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_SHOPPING_CART_TITLE', 'Shopping Cart');
+  define('MODULE_NAVBAR_SHOPPING_CART_DESCRIPTION', 'Show Shopping Cart in Navbar');
+  
+  define('MODULE_NAVBAR_SHOPPING_CART_CONTENTS', '<i class="fa fa-shopping-cart"></i> %s item(s) <span class="caret"></span>');
+  define('MODULE_NAVBAR_SHOPPING_CART_NO_CONTENTS', '<i class="fa fa-shopping-cart"></i> 0 items');
+  define('MODULE_NAVBAR_SHOPPING_CART_HAS_CONTENTS', '%s item(s), %s');
+  define('MODULE_NAVBAR_SHOPPING_CART_VIEW_CART', 'View Cart');
+  define('MODULE_NAVBAR_SHOPPING_CART_CHECKOUT', '<i class="fa fa-angle-right"></i> Checkout');
+  
+  define('MODULE_NAVBAR_SHOPPING_CART_PRODUCT', '<a href="' . tep_href_link('product_info.php', 'products_id=%s') . '">%s x %s</a>');
+  

--- a/includes/languages/english/modules/navbar_modules/nb_special_offers.php
+++ b/includes/languages/english/modules/navbar_modules/nb_special_offers.php
@@ -1,0 +1,17 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com 
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  define('MODULE_NAVBAR_SPECIAL_OFFERS_TITLE', 'Special Offers');
+  define('MODULE_NAVBAR_SPECIAL_OFFERS_DESCRIPTION', 'Show Special Offers Link in Navbar.');
+  
+  define('MODULE_NAVBAR_SPECIAL_OFFERS_PUBLIC_TEXT', '<li><a href="' . tep_href_link('specials.php') . '"><i class="fa fa-fire"></i><span class="hidden-sm"> Special Offers</span></a></li>');
+  

--- a/includes/languages/english/modules/navbar_modules/new_products.php
+++ b/includes/languages/english/modules/navbar_modules/new_products.php
@@ -1,0 +1,5 @@
+<?php
+// in a template so that shopowners 
+// don't have to change the main file! 
+
+echo MODULE_NAVBAR_NEW_PRODUCTS_PUBLIC_TEXT;

--- a/includes/languages/english/modules/navbar_modules/new_products.php
+++ b/includes/languages/english/modules/navbar_modules/new_products.php
@@ -1,5 +1,0 @@
-<?php
-// in a template so that shopowners 
-// don't have to change the main file! 
-
-echo MODULE_NAVBAR_NEW_PRODUCTS_PUBLIC_TEXT;

--- a/includes/modules/content/navigation/cm_navbar.php
+++ b/includes/modules/content/navigation/cm_navbar.php
@@ -5,7 +5,7 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2016 osCommerce
 
   Released under the GNU General Public License
 */
@@ -32,14 +32,36 @@
     }
 
     function execute() {
-      global $PHP_SELF, $cart, $lng, $language, $currencies, $HTTP_GET_VARS, $request_type, $currency, $oscTemplate;
-      global $customer_first_name;
+      global $language, $oscTemplate;
+      
+      if ( defined('MODULE_CONTENT_NAVBAR_INSTALLED') && tep_not_null(MODULE_CONTENT_NAVBAR_INSTALLED) ) {
+        $nav_array = explode(';', MODULE_CONTENT_NAVBAR_INSTALLED);
 
-      ob_start();
-      include(DIR_WS_MODULES . 'content/' . $this->group . '/templates/navbar.php');
-      $template = ob_get_clean();
+        $navbar_modules = array();
 
-      $oscTemplate->addContent($template, $this->group);
+        foreach ( $nav_array as $nbm ) {
+          $class = substr($nbm, 0, strrpos($nbm, '.'));
+
+          if ( !class_exists($class) ) {
+            include(DIR_WS_LANGUAGES . $language . '/modules/navbar_modules/' . $nbm);
+            require(DIR_WS_MODULES . 'navbar_modules/' . $class . '.php');
+          }
+
+          $nav = new $class();
+
+          if ( $nav->isEnabled() ) {
+            $navbar_modules[] = $nav->getOutput();
+          }
+        }
+
+        if ( !empty($navbar_modules) ) {          
+          ob_start();
+          include(DIR_WS_MODULES . 'content/' . $this->group . '/templates/navbar.php');
+          $template = ob_get_clean();
+
+          $oscTemplate->addContent($template, $this->group);
+        }
+      }      
     }
 
     function isEnabled() {
@@ -51,16 +73,15 @@
     }
 
     function install() {
-      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Navbar Module', 'MODULE_CONTENT_NAVBAR_STATUS', 'True', 'Should the Navbar be shown? ', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
-      tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_CONTENT_NAVBAR_SORT_ORDER', '0', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Navbar Module', 'MODULE_CONTENT_NAVBAR_STATUS', 'True', 'Should the Navbar be shown? ', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_CONTENT_NAVBAR_SORT_ORDER', '10', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
     }
 
     function remove() {
-      tep_db_query("delete from " . TABLE_CONFIGURATION . " where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
     }
 
     function keys() {
       return array('MODULE_CONTENT_NAVBAR_STATUS', 'MODULE_CONTENT_NAVBAR_SORT_ORDER');
     }
   }
-

--- a/includes/modules/content/navigation/cm_navbar.php
+++ b/includes/modules/content/navigation/cm_navbar.php
@@ -33,6 +33,10 @@
 
     function execute() {
       global $language, $oscTemplate;
+
+      $navbar_style   = (MODULE_CONTENT_NAVBAR_STYLE == 'Inverse') ? ' navbar-inverse' : ' navbar-default';
+      $navbar_corners = (MODULE_CONTENT_NAVBAR_CORNERS == 'Yes') ? '' : ' navbar-no-corners';
+      $navbar_margin  = (MODULE_CONTENT_NAVBAR_MARGIN == 'Yes') ? '' : ' navbar-no-margin';     
       
       if ( defined('MODULE_CONTENT_NAVBAR_INSTALLED') && tep_not_null(MODULE_CONTENT_NAVBAR_INSTALLED) ) {
         $nav_array = explode(';', MODULE_CONTENT_NAVBAR_INSTALLED);
@@ -74,6 +78,9 @@
 
     function install() {
       tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Navbar Module', 'MODULE_CONTENT_NAVBAR_STATUS', 'True', 'Should the Navbar be shown? ', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Navbar Style', 'MODULE_CONTENT_NAVBAR_STYLE', 'Inverse', 'What style should the Navbar have?  See http://getbootstrap.com/components/#navbar-inverted', '6', '0', 'tep_cfg_select_option(array(\'Default\', \'Inverse\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Navbar Corners', 'MODULE_CONTENT_NAVBAR_CORNERS', 'No', 'Should the Navbar have Corners?', '6', '0', 'tep_cfg_select_option(array(\'Yes\', \'No\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Navbar Margin', 'MODULE_CONTENT_NAVBAR_MARGIN', 'No', 'Should the Navbar have a bottom Margin?', '6', '0', 'tep_cfg_select_option(array(\'Yes\', \'No\'), ', now())");
       tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_CONTENT_NAVBAR_SORT_ORDER', '10', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
     }
 
@@ -82,6 +89,6 @@
     }
 
     function keys() {
-      return array('MODULE_CONTENT_NAVBAR_STATUS', 'MODULE_CONTENT_NAVBAR_SORT_ORDER');
+      return array('MODULE_CONTENT_NAVBAR_STATUS', 'MODULE_CONTENT_NAVBAR_STYLE', 'MODULE_CONTENT_NAVBAR_CORNERS', 'MODULE_CONTENT_NAVBAR_MARGIN', 'MODULE_CONTENT_NAVBAR_SORT_ORDER');
     }
   }

--- a/includes/modules/content/navigation/templates/navbar.php
+++ b/includes/modules/content/navigation/templates/navbar.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-inverse navbar-no-corners navbar-no-margin" role="navigation">
+<nav class="navbar<?php echo $navbar_style . $navbar_corners . $navbar_margin; ?> navbar-custom" role="navigation">
   <div class="<?php echo BOOTSTRAP_CONTAINER; ?>">
     <?php
     if ($oscTemplate->hasBlocks('navbar_modules_home')) {

--- a/includes/modules/content/navigation/templates/navbar.php
+++ b/includes/modules/content/navigation/templates/navbar.php
@@ -1,99 +1,25 @@
 <nav class="navbar navbar-inverse navbar-no-corners navbar-no-margin" role="navigation">
   <div class="<?php echo BOOTSTRAP_CONTAINER; ?>">
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-navbar-collapse-core-nav">
-        <span class="sr-only"><?php echo HEADER_TOGGLE_NAV; ?></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-    </div>
+    <?php
+    if ($oscTemplate->hasBlocks('navbar_modules_home')) {
+      echo '<div class="navbar-header">' . PHP_EOL;
+      echo $oscTemplate->getBlocks('navbar_modules_home');
+      echo '</div>' . PHP_EOL;
+    }
+    ?>      
     <div class="collapse navbar-collapse" id="bs-navbar-collapse-core-nav">
-        <ul class="nav navbar-nav">
-          <?php echo '<li><a class="store-brand" href="' . tep_href_link(FILENAME_DEFAULT) . '">' . HEADER_HOME . '</a></li>'; ?>
-          <?php echo '<li><a href="' . tep_href_link(FILENAME_PRODUCTS_NEW) . '">' . HEADER_WHATS_NEW . '</a></li>'; ?>
-          <?php echo '<li><a href="' . tep_href_link(FILENAME_SPECIALS) . '">' . HEADER_SPECIALS . '</a></li>'; ?>
-          <?php echo '<li><a href="' . tep_href_link(FILENAME_REVIEWS) . '">' . HEADER_REVIEWS . '</a></li>'; ?>
-        </ul>
-        <ul class="nav navbar-nav navbar-right">
-          <?php
-          if (substr(basename($PHP_SELF), 0, 8) != 'checkout') {
-            ?>
-            <li class="dropdown">
-              <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?php echo HEADER_SITE_SETTINGS; ?></a>
-              <ul class="dropdown-menu">
-                <li class="text-center text-muted bg-primary"><?php echo sprintf(USER_LOCALIZATION, ucwords($language), $currency); ?></li>
-                <?php
-                // languages
-                if (!isset($lng) || (isset($lng) && !is_object($lng))) {
-                 include(DIR_WS_CLASSES . 'language.php');
-                  $lng = new language;
-                }
-                if (count($lng->catalog_languages) > 1) {
-                  echo '<li class="divider"></li>';
-                  reset($lng->catalog_languages);
-                  while (list($key, $value) = each($lng->catalog_languages)) {
-                    echo '<li><a href="' . tep_href_link(basename($PHP_SELF), tep_get_all_get_params(array('language', 'currency')) . 'language=' . $key, $request_type) . '">' . tep_image(DIR_WS_LANGUAGES .  $value['directory'] . '/images/' . $value['image'], $value['name'], null, null, null, false) . ' ' . $value['name'] . '</a></li>';
-                  }
-                }
-                // currencies
-                if (isset($currencies) && is_object($currencies) && (count($currencies->currencies) > 1)) {
-                  echo '<li class="divider"></li>';
-                  reset($currencies->currencies);
-                  $currencies_array = array();
-                  while (list($key, $value) = each($currencies->currencies)) {
-                    $currencies_array[] = array('id' => $key, 'text' => $value['title']);
-                    echo '<li><a href="' . tep_href_link(basename($PHP_SELF), tep_get_all_get_params(array('language', 'currency')) . 'currency=' . $key, $request_type) . '">' . $value['title'] . '</a></li>';
-                  }
-                }
-                ?>
-              </ul>
-            </li>
-            <?php
-          }
-          ?>
-          <li class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?php echo (tep_session_is_registered('customer_id')) ? sprintf(HEADER_ACCOUNT_LOGGED_IN, $customer_first_name) : HEADER_ACCOUNT_LOGGED_OUT; ?></a>
-            <ul class="dropdown-menu">
-              <?php
-              if (tep_session_is_registered('customer_id')) {
-                echo '<li><a href="' . tep_href_link(FILENAME_LOGOFF, '', 'SSL') . '">' . HEADER_ACCOUNT_LOGOFF . '</a>';
-              }
-              else {
-                 echo '<li><a href="' . tep_href_link(FILENAME_LOGIN, '', 'SSL') . '">' . HEADER_ACCOUNT_LOGIN . '</a>';
-                 echo '<li><a href="' . tep_href_link(FILENAME_CREATE_ACCOUNT, '', 'SSL') . '">' . HEADER_ACCOUNT_REGISTER . '</a>';
-              }
-              ?>
-              <li class="divider"></li>
-              <li><?php echo '<a href="' . tep_href_link(FILENAME_ACCOUNT, '', 'SSL') . '">' . HEADER_ACCOUNT . '</a>'; ?></li>
-              <li><?php echo '<a href="' . tep_href_link(FILENAME_ACCOUNT_HISTORY, '', 'SSL') . '">' . HEADER_ACCOUNT_HISTORY . '</a>'; ?></li>
-              <li><?php echo '<a href="' . tep_href_link(FILENAME_ADDRESS_BOOK, '', 'SSL') . '">' . HEADER_ACCOUNT_ADDRESS_BOOK . '</a>'; ?></li>
-              <li><?php echo '<a href="' . tep_href_link(FILENAME_ACCOUNT_PASSWORD, '', 'SSL') . '">' . HEADER_ACCOUNT_PASSWORD . '</a>'; ?></li>
-            </ul>
-          </li>
-          <?php
-          if ($cart->count_contents() > 0) {
-            ?>
-            <li class="dropdown">
-              <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?php echo sprintf(HEADER_CART_CONTENTS, $cart->count_contents()); ?></a>
-              <ul class="dropdown-menu">
-                <li><?php echo '<a href="' . tep_href_link(FILENAME_SHOPPING_CART) . '">' . sprintf(HEADER_CART_HAS_CONTENTS, $cart->count_contents(), $currencies->format($cart->show_total())) . '</a>'; ?></li>
-                <?php
-                if ($cart->count_contents() > 0) {
-                  echo '<li class="divider"></li>';
-                  echo '<li><a href="' . tep_href_link(FILENAME_SHOPPING_CART) . '">' . HEADER_CART_VIEW_CART . '</a></li>';
-                }
-                ?>
-              </ul>
-            </li>
-            <?php
-            echo '<li><a href="' . tep_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL') . '">' . HEADER_CART_CHECKOUT . '</a></li>';
-          }
-          else {
-            echo '<li class="nav navbar-text">' . HEADER_CART_NO_CONTENTS . '</li>';
-          }
-          ?>
-        </ul>
+      <?php
+      if ($oscTemplate->hasBlocks('navbar_modules_left')) {
+        echo '<ul class="nav navbar-nav">' . PHP_EOL;
+        echo $oscTemplate->getBlocks('navbar_modules_left');
+        echo '</ul>' . PHP_EOL;
+      }
+      if ($oscTemplate->hasBlocks('navbar_modules_right')) {
+        echo '<ul class="nav navbar-nav navbar-right">' . PHP_EOL;
+        echo $oscTemplate->getBlocks('navbar_modules_right');
+        echo '</ul>' . PHP_EOL;
+      }
+      ?>
     </div>
   </div>
 </nav>

--- a/includes/modules/navbar_modules/nb_account.php
+++ b/includes/modules/navbar_modules/nb_account.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions 
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_account {
+    var $code = 'nb_account';
+    var $group = 'navbar_modules_right';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_account() {
+      $this->title = MODULE_NAVBAR_ACCOUNT_TITLE;
+      $this->description = MODULE_NAVBAR_ACCOUNT_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_ACCOUNT_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_ACCOUNT_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_ACCOUNT_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_ACCOUNT_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate, $customer_first_name, $customer_id;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/account.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_ACCOUNT_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Account Module', 'MODULE_NAVBAR_ACCOUNT_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_ACCOUNT_CONTENT_PLACEMENT', 'Right', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_ACCOUNT_SORT_ORDER', '540', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_ACCOUNT_STATUS', 'MODULE_NAVBAR_ACCOUNT_CONTENT_PLACEMENT', 'MODULE_NAVBAR_ACCOUNT_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_brand.php
+++ b/includes/modules/navbar_modules/nb_brand.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions 
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_brand {
+    var $code = 'nb_brand';
+    var $group = 'navbar_modules_home';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_brand() {
+      $this->title = MODULE_NAVBAR_BRAND_TITLE;
+      $this->description = MODULE_NAVBAR_BRAND_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_BRAND_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_BRAND_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_BRAND_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_BRAND_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/brand.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_BRAND_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Brand Module', 'MODULE_NAVBAR_BRAND_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_BRAND_CONTENT_PLACEMENT', 'Home', 'This module must be placed in the Home area of the Navbar.', '6', '1', 'tep_cfg_select_option(array(\'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_BRAND_SORT_ORDER', '505', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_BRAND_STATUS', 'MODULE_NAVBAR_BRAND_CONTENT_PLACEMENT', 'MODULE_NAVBAR_BRAND_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_currencies.php
+++ b/includes/modules/navbar_modules/nb_currencies.php
@@ -1,0 +1,77 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions 
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_currencies {
+    var $code = 'nb_currencies';
+    var $group = 'navbar_modules_right';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_currencies() {
+      $this->title = MODULE_NAVBAR_CURRENCIES_TITLE;
+      $this->description = MODULE_NAVBAR_CURRENCIES_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_CURRENCIES_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_CURRENCIES_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_CURRENCIES_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_CURRENCIES_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate, $cart, $currencies, $PHP_SELF, $request_type, $currency;
+      
+      if (substr(basename($PHP_SELF), 0, 8) != 'checkout') {
+        ob_start();
+        require(DIR_WS_MODULES . 'navbar_modules/templates/currencies.php');
+        $data = ob_get_clean();
+
+        $oscTemplate->addBlock($data, $this->group);
+      }
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_CURRENCIES_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Currencies Module', 'MODULE_NAVBAR_CURRENCIES_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_CURRENCIES_CONTENT_PLACEMENT', 'Right', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_CURRENCIES_SORT_ORDER', '530', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_CURRENCIES_STATUS', 'MODULE_NAVBAR_CURRENCIES_CONTENT_PLACEMENT', 'MODULE_NAVBAR_CURRENCIES_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_hamburger_button.php
+++ b/includes/modules/navbar_modules/nb_hamburger_button.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_hamburger_button {
+    var $code = 'nb_hamburger_button';
+    var $group = 'navbar_modules_home';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_hamburger_button() {
+      $this->title = MODULE_NAVBAR_HAMBURGER_BUTTON_TITLE;
+      $this->description = MODULE_NAVBAR_HAMBURGER_BUTTON_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_HAMBURGER_BUTTON_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_HAMBURGER_BUTTON_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_HAMBURGER_BUTTON_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_HAMBURGER_BUTTON_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/hamburger_button.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_HAMBURGER_BUTTON_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Hamburger Button Module', 'MODULE_NAVBAR_HAMBURGER_BUTTON_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_HAMBURGER_BUTTON_CONTENT_PLACEMENT', 'Home', 'This module must be placed in the Home area of the Navbar.', '6', '1', 'tep_cfg_select_option(array(\'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_HAMBURGER_BUTTON_SORT_ORDER', '500', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_HAMBURGER_BUTTON_STATUS', 'MODULE_NAVBAR_HAMBURGER_BUTTON_CONTENT_PLACEMENT', 'MODULE_NAVBAR_HAMBURGER_BUTTON_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_home.php
+++ b/includes/modules/navbar_modules/nb_home.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_home {
+    var $code = 'nb_home';
+    var $group = 'navbar_modules_home';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_home() {
+      $this->title = MODULE_NAVBAR_HOME_TITLE;
+      $this->description = MODULE_NAVBAR_HOME_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_HOME_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_HOME_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_HOME_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_HOME_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/home.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_HOME_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Home Module', 'MODULE_NAVBAR_HOME_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_HOME_CONTENT_PLACEMENT', 'Left', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_HOME_SORT_ORDER', '520', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_HOME_STATUS', 'MODULE_NAVBAR_HOME_CONTENT_PLACEMENT', 'MODULE_NAVBAR_HOME_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_languages.php
+++ b/includes/modules/navbar_modules/nb_languages.php
@@ -1,0 +1,77 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions 
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_languages {
+    var $code = 'nb_languages';
+    var $group = 'navbar_modules_right';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_languages() {
+      $this->title = MODULE_NAVBAR_LANGUAGES_TITLE;
+      $this->description = MODULE_NAVBAR_LANGUAGES_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_LANGUAGES_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_LANGUAGES_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_LANGUAGES_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_LANGUAGES_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate, $cart, $currencies, $PHP_SELF, $request_type, $currency, $lng;
+      
+      if (substr(basename($PHP_SELF), 0, 8) != 'checkout') {
+        ob_start();
+        require(DIR_WS_MODULES . 'navbar_modules/templates/languages.php');
+        $data = ob_get_clean();
+
+        $oscTemplate->addBlock($data, $this->group);
+      }
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_LANGUAGES_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Languages Module', 'MODULE_NAVBAR_LANGUAGES_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_LANGUAGES_CONTENT_PLACEMENT', 'Right', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_LANGUAGES_SORT_ORDER', '535', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_LANGUAGES_STATUS', 'MODULE_NAVBAR_LANGUAGES_CONTENT_PLACEMENT', 'MODULE_NAVBAR_LANGUAGES_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_new_products.php
+++ b/includes/modules/navbar_modules/nb_new_products.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com 
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_new_products {
+    var $code = 'nb_new_products';
+    var $group = 'navbar_modules_home';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_new_products() {
+      $this->title = MODULE_NAVBAR_NEW_PRODUCTS_TITLE;
+      $this->description = MODULE_NAVBAR_NEW_PRODUCTS_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_NEW_PRODUCTS_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_NEW_PRODUCTS_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_NEW_PRODUCTS_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_NEW_PRODUCTS_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/new_products.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_NEW_PRODUCTS_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable New Products Module', 'MODULE_NAVBAR_NEW_PRODUCTS_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_NEW_PRODUCTS_CONTENT_PLACEMENT', 'Left', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_NEW_PRODUCTS_SORT_ORDER', '525', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_NEW_PRODUCTS_STATUS', 'MODULE_NAVBAR_NEW_PRODUCTS_CONTENT_PLACEMENT', 'MODULE_NAVBAR_NEW_PRODUCTS_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_reviews.php
+++ b/includes/modules/navbar_modules/nb_reviews.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_reviews {
+    var $code = 'nb_reviews';
+    var $group = 'navbar_modules_home';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_reviews() {
+      $this->title = MODULE_NAVBAR_REVIEWS_TITLE;
+      $this->description = MODULE_NAVBAR_REVIEWS_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_REVIEWS_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_REVIEWS_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_REVIEWS_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_REVIEWS_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/reviews.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_REVIEWS_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Reviews Module', 'MODULE_NAVBAR_REVIEWS_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_REVIEWS_CONTENT_PLACEMENT', 'Left', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_REVIEWS_SORT_ORDER', '535', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_REVIEWS_STATUS', 'MODULE_NAVBAR_REVIEWS_CONTENT_PLACEMENT', 'MODULE_NAVBAR_REVIEWS_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_shopping_cart.php
+++ b/includes/modules/navbar_modules/nb_shopping_cart.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_shopping_cart {
+    var $code = 'nb_shopping_cart';
+    var $group = 'navbar_modules_right';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_shopping_cart() {
+      $this->title = MODULE_NAVBAR_SHOPPING_CART_TITLE;
+      $this->description = MODULE_NAVBAR_SHOPPING_CART_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_SHOPPING_CART_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_SHOPPING_CART_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_SHOPPING_CART_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_SHOPPING_CART_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate, $cart, $currencies;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/shopping_cart.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_SHOPPING_CART_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Shopping Cart Module', 'MODULE_NAVBAR_SHOPPING_CART_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_SHOPPING_CART_CONTENT_PLACEMENT', 'Right', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_SHOPPING_CART_SORT_ORDER', '550', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_SHOPPING_CART_STATUS', 'MODULE_NAVBAR_SHOPPING_CART_CONTENT_PLACEMENT', 'MODULE_NAVBAR_SHOPPING_CART_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/nb_special_offers.php
+++ b/includes/modules/navbar_modules/nb_special_offers.php
@@ -1,0 +1,75 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com 
+
+  Copyright (c) 2016 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  class nb_special_offers {
+    var $code = 'nb_special_offers';
+    var $group = 'navbar_modules_home';
+    var $title;
+    var $description;
+    var $sort_order;
+    var $enabled = false;    
+    
+    function nb_special_offers() {
+      $this->title = MODULE_NAVBAR_SPECIAL_OFFERS_TITLE;
+      $this->description = MODULE_NAVBAR_SPECIAL_OFFERS_DESCRIPTION;
+
+      if ( defined('MODULE_NAVBAR_SPECIAL_OFFERS_STATUS') ) {
+        $this->sort_order = MODULE_NAVBAR_SPECIAL_OFFERS_SORT_ORDER;
+        $this->enabled = (MODULE_NAVBAR_SPECIAL_OFFERS_STATUS == 'True');
+        
+        switch (MODULE_NAVBAR_SPECIAL_OFFERS_CONTENT_PLACEMENT) {
+          case 'Home':
+          $this->group = 'navbar_modules_home';
+          break;
+          case 'Left':
+          $this->group = 'navbar_modules_left';
+          break;
+          case 'Right':
+          $this->group = 'navbar_modules_right';
+          break;
+        } 
+      }
+    }
+
+    function getOutput() {
+      global $oscTemplate;
+      
+      ob_start();
+      require(DIR_WS_MODULES . 'navbar_modules/templates/special_offers.php');
+      $data = ob_get_clean();
+
+      $oscTemplate->addBlock($data, $this->group);
+    }
+
+    function isEnabled() {
+      return $this->enabled;
+    }
+
+    function check() {
+      return defined('MODULE_NAVBAR_SPECIAL_OFFERS_STATUS');
+    }
+
+    function install() {
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable Special Offers Module', 'MODULE_NAVBAR_SPECIAL_OFFERS_STATUS', 'True', 'Do you want to add the module to your Navbar?', '6', '1', 'tep_cfg_select_option(array(\'True\', \'False\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Content Placement', 'MODULE_NAVBAR_SPECIAL_OFFERS_CONTENT_PLACEMENT', 'Left', 'Should the module be loaded in the Left or Right or the Home area of the Navbar?', '6', '1', 'tep_cfg_select_option(array(\'Left\', \'Right\', \'Home\'), ', now())");
+      tep_db_query("insert into configuration (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort Order', 'MODULE_NAVBAR_SPECIAL_OFFERS_SORT_ORDER', '530', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
+    }
+
+    function remove() {
+      tep_db_query("delete from configuration where configuration_key in ('" . implode("', '", $this->keys()) . "')");
+    }
+
+    function keys() {
+      return array('MODULE_NAVBAR_SPECIAL_OFFERS_STATUS', 'MODULE_NAVBAR_SPECIAL_OFFERS_CONTENT_PLACEMENT', 'MODULE_NAVBAR_SPECIAL_OFFERS_SORT_ORDER');
+    }
+  }
+  

--- a/includes/modules/navbar_modules/templates/account.php
+++ b/includes/modules/navbar_modules/templates/account.php
@@ -1,0 +1,19 @@
+<li class="dropdown"> 
+  <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?php echo (tep_session_is_registered('customer_id')) ? sprintf(MODULE_NAVBAR_ACCOUNT_LOGGED_IN, $customer_first_name) : MODULE_NAVBAR_ACCOUNT_LOGGED_OUT; ?></a>
+  <ul class="dropdown-menu">
+    <?php
+    if (tep_session_is_registered('customer_id')) {
+      echo '<li><a href="' . tep_href_link('logoff.php', '', 'SSL') . '">' . MODULE_NAVBAR_ACCOUNT_LOGOFF . '</a>';
+    }
+    else {
+      echo '<li><a href="' . tep_href_link('login.php', '', 'SSL') . '">' . MODULE_NAVBAR_ACCOUNT_LOGIN . '</a>';
+      echo '<li><a href="' . tep_href_link('create_account.php', '', 'SSL') . '">' . MODULE_NAVBAR_ACCOUNT_REGISTER . '</a>';
+    }
+    ?>
+    <li class="divider"></li>
+    <li><?php echo '<a href="' . tep_href_link('account.php', '', 'SSL') . '">' . MODULE_NAVBAR_ACCOUNT . '</a>'; ?></li>
+    <li><?php echo '<a href="' . tep_href_link('account_history.php', '', 'SSL') . '">' . MODULE_NAVBAR_ACCOUNT_HISTORY . '</a>'; ?></li>
+    <li><?php echo '<a href="' . tep_href_link('address_book.php', '', 'SSL') . '">' . MODULE_NAVBAR_ACCOUNT_ADDRESS_BOOK . '</a>'; ?></li>
+    <li><?php echo '<a href="' . tep_href_link('account_password.php', '', 'SSL') . '">' . MODULE_NAVBAR_ACCOUNT_PASSWORD . '</a>'; ?></li>
+  </ul>
+</li>

--- a/includes/modules/navbar_modules/templates/brand.php
+++ b/includes/modules/navbar_modules/templates/brand.php
@@ -1,0 +1,5 @@
+<?php
+// in a template so that shopowners 
+// don't have to change the main file! 
+
+echo MODULE_NAVBAR_BRAND_PUBLIC_TEXT;

--- a/includes/modules/navbar_modules/templates/currencies.php
+++ b/includes/modules/navbar_modules/templates/currencies.php
@@ -1,0 +1,21 @@
+<li class="dropdown"> 
+  <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+  <?php echo sprintf(MODULE_NAVBAR_CURRENCIES_SELECTED_CURRENCY, $currency); ?>
+  </a>
+  <?php
+  if (isset($currencies) && is_object($currencies) && (count($currencies->currencies) > 1)) {
+    ?>
+    <ul class="dropdown-menu">
+      <?php                
+      reset($currencies->currencies);
+      $currencies_array = array();
+      while (list($key, $value) = each($currencies->currencies)) {
+        $currencies_array[] = array('id' => $key, 'text' => $value['title']);
+        echo '<li><a href="' . tep_href_link(basename($PHP_SELF), tep_get_all_get_params(array('language', 'currency')) . 'currency=' . $key, $request_type) . '">' . $value['title'] . '</a></li>';
+      }
+      ?>
+    </ul>
+    <?php
+  }
+  ?>
+</li>         

--- a/includes/modules/navbar_modules/templates/hamburger_button.php
+++ b/includes/modules/navbar_modules/templates/hamburger_button.php
@@ -1,0 +1,4 @@
+<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-navbar-collapse-core-nav">
+  <?php echo MODULE_NAVBAR_HAMBURGER_BUTTON_PUBLIC_SCREENREADER_TEXT; ?>
+  <?php echo MODULE_NAVBAR_HAMBURGER_BUTTON_PUBLIC_BUTTON_TEXT; ?>
+</button>

--- a/includes/modules/navbar_modules/templates/home.php
+++ b/includes/modules/navbar_modules/templates/home.php
@@ -1,0 +1,5 @@
+<?php
+// in a template so that shopowners 
+// don't have to change the main file!
+
+echo MODULE_NAVBAR_HOME_PUBLIC_TEXT;

--- a/includes/modules/navbar_modules/templates/languages.php
+++ b/includes/modules/navbar_modules/templates/languages.php
@@ -1,0 +1,21 @@
+<li class="dropdown">
+  <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?php echo MODULE_NAVBAR_LANGUAGES_SELECTED_LANGUAGE; ?></a>
+  <?php
+  if (!isset($lng) || (isset($lng) && !is_object($lng))) { 
+    include(DIR_WS_CLASSES . 'language.php');
+    $lng = new language;
+  }
+  if (count($lng->catalog_languages) > 1) {
+    ?>
+    <ul class="dropdown-menu">
+      <?php   
+      reset($lng->catalog_languages);
+      while (list($key, $value) = each($lng->catalog_languages)) {
+        echo '<li><a href="' . tep_href_link(basename($PHP_SELF), tep_get_all_get_params(array('language', 'currency')) . 'language=' . $key, $request_type) . '">' . tep_image(DIR_WS_LANGUAGES .  $value['directory'] . '/images/' . $value['image'], $value['name'], null, null, null, false) . ' ' . $value['name'] . '</a></li>';
+      }
+      ?>
+    </ul>
+    <?php
+    }
+  ?>
+</li>    

--- a/includes/modules/navbar_modules/templates/new_products.php
+++ b/includes/modules/navbar_modules/templates/new_products.php
@@ -1,0 +1,5 @@
+<?php
+// in a template so that shopowners 
+// don't have to change the main file!  
+
+echo MODULE_NAVBAR_NEW_PRODUCTS_PUBLIC_TEXT;

--- a/includes/modules/navbar_modules/templates/reviews.php
+++ b/includes/modules/navbar_modules/templates/reviews.php
@@ -1,0 +1,5 @@
+<?php
+// in a template so that shopowners  
+// don't have to change the main file!
+
+echo MODULE_NAVBAR_REVIEWS_PUBLIC_TEXT;

--- a/includes/modules/navbar_modules/templates/shopping_cart.php
+++ b/includes/modules/navbar_modules/templates/shopping_cart.php
@@ -1,0 +1,25 @@
+<?php
+if ($cart->count_contents() > 0) {
+  ?>
+  <li class="dropdown">
+    <a class="dropdown-toggle" data-toggle="dropdown" href="#"><?php echo sprintf(MODULE_NAVBAR_SHOPPING_CART_CONTENTS, $cart->count_contents()); ?></a>
+    <ul class="dropdown-menu">
+      <li><?php echo '<a href="' . tep_href_link('shopping_cart.php') . '">' . sprintf(MODULE_NAVBAR_SHOPPING_CART_HAS_CONTENTS, $cart->count_contents(), $currencies->format($cart->show_total())) . '</a>'; ?></li>
+      <li role="separator" class="divider"></li>
+      <?php      
+      $products = $cart->get_products();
+      foreach ($products as $k => $v) {
+        echo '<li>' . sprintf(MODULE_NAVBAR_SHOPPING_CART_PRODUCT, $v['id'], $v['quantity'], $v['name']) . '</li>';
+      }        
+      ?>
+      <li role="separator" class="divider"></li>
+      <li><?php echo '<a href="' . tep_href_link('shopping_cart.php') . '">' . MODULE_NAVBAR_SHOPPING_CART_VIEW_CART . '</a>'; ?></li>
+    </ul>
+  </li>
+  <?php
+  echo '<li><a href="' . tep_href_link('checkout_shipping.php', '', 'SSL') . '">' . MODULE_NAVBAR_SHOPPING_CART_CHECKOUT . '</a></li>';
+}
+else {
+  echo '<li class="nav navbar-text">' . MODULE_NAVBAR_SHOPPING_CART_NO_CONTENTS . '</li>';
+}
+?>

--- a/includes/modules/navbar_modules/templates/special_offers.php
+++ b/includes/modules/navbar_modules/templates/special_offers.php
@@ -1,0 +1,5 @@
+<?php
+// in a template so that shopowners  
+// don't have to change the main file!
+
+echo MODULE_NAVBAR_SPECIAL_OFFERS_PUBLIC_TEXT;


### PR DESCRIPTION
This allows shopowner to mix and match the Navbar as they want on a shop by shop basis...

+ Shopowner should never have to touch the main module, just turn on/off su-bmodules
- Shopowner needs to build sub-modules if they wish to do something in the Navbar that is "unusual"

Previously this was a simple "change this template" file to add/remove from Nav, but pointy-clicky seems nicer to most shopowners.  We shall see what the reaction is when it is realised how pointy-clicky leads to more complicated code to do something relatively simplistic...