### PR TITLE
Full localization support for order status emails

### DIFF
--- a/admin/includes/classes/order.php
+++ b/admin/includes/classes/order.php
@@ -24,7 +24,7 @@
     }
 
     function query($order_id) {
-      $order_query = tep_db_query("select customers_name, customers_company, customers_street_address, customers_suburb, customers_city, customers_postcode, customers_state, customers_country, customers_telephone, customers_email_address, customers_address_format_id, delivery_name, delivery_company, delivery_street_address, delivery_suburb, delivery_city, delivery_postcode, delivery_state, delivery_country, delivery_address_format_id, billing_name, billing_company, billing_street_address, billing_suburb, billing_city, billing_postcode, billing_state, billing_country, billing_address_format_id, payment_method, cc_type, cc_owner, cc_number, cc_expires, currency, currency_value, date_purchased, orders_status, last_modified from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
+      $order_query = tep_db_query("select customers_name, customers_company, customers_street_address, customers_suburb, customers_city, customers_postcode, customers_state, customers_country, customers_telephone, customers_email_address, customers_address_format_id, delivery_name, delivery_company, delivery_street_address, delivery_suburb, delivery_city, delivery_postcode, delivery_state, delivery_country, delivery_address_format_id, billing_name, billing_company, billing_street_address, billing_suburb, billing_city, billing_postcode, billing_state, billing_country, billing_address_format_id, payment_method, cc_type, cc_owner, cc_number, cc_expires, currency, currency_value, date_purchased, orders_status, last_modified, language_id from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
       $order = tep_db_fetch_array($order_query);
 
       $totals_query = tep_db_query("select title, text from " . TABLE_ORDERS_TOTAL . " where orders_id = '" . (int)$order_id . "' order by sort_order");
@@ -42,7 +42,8 @@
                           'cc_expires' => $order['cc_expires'],
                           'date_purchased' => $order['date_purchased'],
                           'orders_status' => $order['orders_status'],
-                          'last_modified' => $order['last_modified']);
+                          'last_modified' => $order['last_modified'],
+                          'language_id' => $order['language_id']);
 
       $this->customer = array('name' => $order['customers_name'],
                               'company' => $order['customers_company'],

--- a/admin/includes/languages/english/email_constants.php
+++ b/admin/includes/languages/english/email_constants.php
@@ -1,0 +1,19 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 201 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+define('EMAIL_SEPARATOR', '------------------------------------------------------');
+define('EMAIL_TEXT_SUBJECT', 'Order Update');
+define('EMAIL_TEXT_ORDER_NUMBER', 'Order Number:');
+define('EMAIL_TEXT_INVOICE_URL', 'Detailed Invoice:');
+define('EMAIL_TEXT_DATE_ORDERED', 'Date Ordered:');
+define('EMAIL_TEXT_STATUS_UPDATE', 'Your order has been updated to the following status.' . "\n\n" . 'New status: %s' . "\n\n" . 'Please reply to this email if you have any questions.' . "\n");
+define('EMAIL_TEXT_COMMENTS_UPDATE', 'The comments for your order are' . "\n\n%s\n\n");

--- a/admin/includes/languages/english/orders.php
+++ b/admin/includes/languages/english/orders.php
@@ -65,15 +65,6 @@ define('TEXT_INFO_PAYMENT_METHOD', 'Payment Method:');
 define('TEXT_ALL_ORDERS', 'All Orders');
 define('TEXT_NO_ORDER_HISTORY', 'No Order History Available');
 
-define('EMAIL_SEPARATOR', '------------------------------------------------------');
-define('EMAIL_TEXT_SUBJECT', 'Order Update');
-define('EMAIL_TEXT_ORDER_NUMBER', 'Order Number:');
-define('EMAIL_TEXT_INVOICE_URL', 'Detailed Invoice:');
-define('EMAIL_TEXT_DATE_ORDERED', 'Date Ordered:');
-define('EMAIL_TEXT_STATUS_UPDATE', 'Your order has been updated to the following status.' . "\n\n" . 'New status: %s' . "\n\n" . 'Please reply to this email if you have any questions.' . "\n");
-define('EMAIL_TEXT_COMMENTS_UPDATE', 'The comments for your order are' . "\n\n%s\n\n");
-
 define('ERROR_ORDER_DOES_NOT_EXIST', 'Error: Order does not exist.');
 define('SUCCESS_ORDER_UPDATED', 'Success: Order has been successfully updated.');
 define('WARNING_ORDER_NOT_UPDATED', 'Warning: Nothing to change. The order was not updated.');
-?>

--- a/checkout_process.php
+++ b/checkout_process.php
@@ -118,7 +118,9 @@
                           'date_purchased' => 'now()', 
                           'orders_status' => $order->info['order_status'], 
                           'currency' => $order->info['currency'], 
-                          'currency_value' => $order->info['currency_value']);
+                          'currency_value' => $order->info['currency_value'],
+                          'language_id' => $order->info['language_id'],
+                          );
   tep_db_perform(TABLE_ORDERS, $sql_data_array);
   $insert_id = tep_db_insert_id();
   for ($i=0, $n=sizeof($order_totals); $i<$n; $i++) {

--- a/includes/classes/order.php
+++ b/includes/classes/order.php
@@ -32,7 +32,7 @@
 
       $order_id = tep_db_prepare_input($order_id);
 
-      $order_query = tep_db_query("select customers_id, customers_name, customers_company, customers_street_address, customers_suburb, customers_city, customers_postcode, customers_state, customers_country, customers_telephone, customers_email_address, customers_address_format_id, delivery_name, delivery_company, delivery_street_address, delivery_suburb, delivery_city, delivery_postcode, delivery_state, delivery_country, delivery_address_format_id, billing_name, billing_company, billing_street_address, billing_suburb, billing_city, billing_postcode, billing_state, billing_country, billing_address_format_id, payment_method, cc_type, cc_owner, cc_number, cc_expires, currency, currency_value, date_purchased, orders_status, last_modified from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
+      $order_query = tep_db_query("select customers_id, customers_name, customers_company, customers_street_address, customers_suburb, customers_city, customers_postcode, customers_state, customers_country, customers_telephone, customers_email_address, customers_address_format_id, delivery_name, delivery_company, delivery_street_address, delivery_suburb, delivery_city, delivery_postcode, delivery_state, delivery_country, delivery_address_format_id, billing_name, billing_company, billing_street_address, billing_suburb, billing_city, billing_postcode, billing_state, billing_country, billing_address_format_id, payment_method, cc_type, cc_owner, cc_number, cc_expires, currency, currency_value, date_purchased, orders_status, last_modified, language_id from " . TABLE_ORDERS . " where orders_id = '" . (int)$order_id . "'");
       $order = tep_db_fetch_array($order_query);
 
       $totals_query = tep_db_query("select title, text from " . TABLE_ORDERS_TOTAL . " where orders_id = '" . (int)$order_id . "' order by sort_order");
@@ -61,7 +61,8 @@
                           'orders_status' => $order_status['orders_status_name'],
                           'last_modified' => $order['last_modified'],
                           'total' => strip_tags($order_total['text']),
-                          'shipping_method' => ((substr($shipping_method['title'], -1) == ':') ? substr(strip_tags($shipping_method['title']), 0, -1) : strip_tags($shipping_method['title'])));
+                          'shipping_method' => ((substr($shipping_method['title'], -1) == ':') ? substr(strip_tags($shipping_method['title']), 0, -1) : strip_tags($shipping_method['title'])),
+                          'language_id' => $order['language_id']);
 
       $this->customer = array('id' => $order['customers_id'],
                               'name' => $order['customers_name'],
@@ -224,7 +225,8 @@
                           'subtotal' => 0,
                           'tax' => 0,
                           'tax_groups' => array(),
-                          'comments' => (tep_session_is_registered('comments') && !empty($comments) ? $comments : ''));
+                          'comments' => (tep_session_is_registered('comments') && !empty($comments) ? $comments : ''),
+                          'language_id' => (int)$languages_id);
 
       if (isset($GLOBALS[$payment]) && is_object($GLOBALS[$payment])) {
         if (isset($GLOBALS[$payment]->public_title)) {

--- a/install/oscommerce.sql
+++ b/install/oscommerce.sql
@@ -317,6 +317,7 @@ CREATE TABLE orders (
   orders_date_finished datetime,
   currency char(3),
   currency_value decimal(14,6),
+  language_id int(11) NOT NULL,
   PRIMARY KEY (orders_id),
   KEY idx_orders_customers_id (customers_id)
 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;

--- a/install/templates/main_page.php
+++ b/install/templates/main_page.php
@@ -23,7 +23,7 @@
 
 <!-- Bootstrap -->
 <link href="../ext/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-<script src="../ext/jquery/jquery-2.2.2.min.js"></script>
+<script src="../ext/jquery/jquery-2.2.3.min.js"></script>
 <script src="../ext/bootstrap/js/bootstrap.min.js"></script>
 <!-- Custom -->
 <link rel="stylesheet" href="templates/main_page/stylesheet.css" />


### PR DESCRIPTION
Adds localization for order status emails in the customers chosen language when the order was placed.
- Language id is added to orders table when an order is placed so it can
be identified later.
- Moved all email text constants from
admin/includes/languages/language_x/orders.php to their own file
(admin/includes/languages/language_x/email_constants.php).
- Language flag added to order comments header to remember admin the
language used in the order.
- Both order classes modified to store the language in
$order->info['language_id'].
Tested and working under a dual language setup.