### PR TITLE
php 7 admin/classes changes - class name method is no longer constructor

### DIFF
--- a/admin/includes/classes/action_recorder.php
+++ b/admin/includes/classes/action_recorder.php
@@ -13,7 +13,7 @@
   require(DIR_FS_CATALOG . 'includes/classes/action_recorder.php');
 
   class actionRecorderAdmin extends actionRecorder {
-    function actionRecorderAdmin($module, $user_id = null, $user_name = null) {
+    function __construct($module, $user_id = null, $user_name = null) {
       global $language, $PHP_SELF;
 
       $module = tep_sanitize_string(str_replace(' ', '', $module));

--- a/admin/includes/classes/box.php
+++ b/admin/includes/classes/box.php
@@ -24,10 +24,10 @@
 */
 
   class box extends tableBlock {
-    function box() {
+		function __construct() {
       $this->heading = array();
       $this->contents = array();
-    }
+    } 
 
     function infoBox($heading, $contents) {
       $this->table_row_parameters = 'class="infoBoxHeading"';

--- a/admin/includes/classes/cfg_modules.php
+++ b/admin/includes/classes/cfg_modules.php
@@ -13,7 +13,7 @@
   class cfg_modules {
     var $_modules = array();
 
-    function cfg_modules() {
+    function __construct() {
       global $PHP_SELF, $language;
 
       $file_extension = substr($PHP_SELF, strrpos($PHP_SELF, '.'));

--- a/admin/includes/classes/currencies.php
+++ b/admin/includes/classes/currencies.php
@@ -17,7 +17,7 @@
     var $currencies;
 
 // class constructor
-    function currencies() {
+    function __construct() {
       $this->currencies = array();
       $currencies_query = tep_db_query("select code, title, symbol_left, symbol_right, decimal_point, thousands_point, decimal_places, value from " . TABLE_CURRENCIES);
       while ($currencies = tep_db_fetch_array($currencies_query)) {

--- a/admin/includes/classes/email.php
+++ b/admin/includes/classes/email.php
@@ -28,7 +28,7 @@
     var $attachments;
     var $headers;
 
-    function email($headers = '') {
+    function __construct($headers = '') {
       if ($headers == '') $headers = array();
 
       $this->html_images = array();

--- a/admin/includes/classes/language.php
+++ b/admin/includes/classes/language.php
@@ -16,7 +16,7 @@
   class language {
     var $languages, $catalog_languages, $browser_languages, $language;
 
-    function language($lng = '') {
+    function __construct($lng = '') {
       $this->languages = array('af' => 'af|afrikaans',
                                'ar' => 'ar([-_][[:alpha:]]{2})?|arabic',
                                'be' => 'be|belarusian',

--- a/admin/includes/classes/logger.php
+++ b/admin/includes/classes/logger.php
@@ -14,7 +14,7 @@
     var $timer_start, $timer_stop, $timer_total;
 
 // class constructor
-    function logger() {
+    function __construct() {
       $this->timer_start();
     }
 

--- a/admin/includes/classes/message_stack.php
+++ b/admin/includes/classes/message_stack.php
@@ -19,8 +19,8 @@
 
   class messageStack extends tableBlock {
     var $size = 0;
-
-    function messageStack() {
+		
+		function __construct() {
       global $messageToStack;
 
       $this->errors = array();

--- a/admin/includes/classes/mime.php
+++ b/admin/includes/classes/mime.php
@@ -38,7 +38,7 @@
  * @access public
  */
 
-    function mime($body, $params = '') {
+    function __construct($body, $params = '') {
       if ($params == '') $params = array();
 
 // Make sure we use the correct linfeed sequence

--- a/admin/includes/classes/object_info.php
+++ b/admin/includes/classes/object_info.php
@@ -13,6 +13,10 @@
   class objectInfo {
 
 // class constructor
+    function __construct($object_array) {
+		  $this->objectInfo($object_array);
+		}
+
     function objectInfo($object_array) {
       reset($object_array);
       while (list($key, $value) = each($object_array)) {

--- a/admin/includes/classes/order.php
+++ b/admin/includes/classes/order.php
@@ -13,7 +13,7 @@
   class order {
     var $info, $totals, $products, $customer, $delivery;
 
-    function order($order_id) {
+    function __construct($order_id) {
       $this->info = array();
       $this->totals = array();
       $this->products = array();

--- a/admin/includes/classes/passwordhash.php
+++ b/admin/includes/classes/passwordhash.php
@@ -35,7 +35,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 

--- a/admin/includes/classes/phplot.php
+++ b/admin/includes/classes/phplot.php
@@ -169,7 +169,7 @@ class PHPlot{
 //BEGIN CODE
 //////////////////////////////////////////////////////
 	//Constructor: Setup Img pointer, Colors and Size of Image
-	function PHPlot($which_width=600,$which_height=400,$which_output_file="",$which_input_file="") {
+	function __construct($which_width=600,$which_height=400,$which_output_file="",$which_input_file="") {
 
 		$this->SetRGBArray('2'); 
 		$this->background_done = 0; //Set to 1 after background image first drawn

--- a/admin/includes/classes/shopping_cart.php
+++ b/admin/includes/classes/shopping_cart.php
@@ -13,6 +13,9 @@
   class shoppingCart {
     var $contents, $total, $weight;
 
+    function __construct() {
+		}
+
     function shoppingCart() {
       $this->reset();
     }

--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -11,7 +11,7 @@
 */
 
   class splitPageResults {
-    function splitPageResults(&$current_page_number, $max_rows_per_page, &$sql_query, &$query_num_rows) {
+    function __construct(&$current_page_number, $max_rows_per_page, &$sql_query, &$query_num_rows) {
       if (empty($current_page_number)) $current_page_number = 1;
 
       $pos_to = strlen($sql_query);

--- a/admin/includes/classes/table_block.php
+++ b/admin/includes/classes/table_block.php
@@ -19,6 +19,10 @@
     var $table_row_parameters = '';
     var $table_data_parameters = '';
 
+		function __construct($contents) {
+		  $this->tableBlock($contents);
+		}
+
     function tableBlock($contents) {
       $tableBox_string = '';
 

--- a/admin/includes/classes/table_block.php
+++ b/admin/includes/classes/table_block.php
@@ -19,8 +19,7 @@
     var $table_row_parameters = '';
     var $table_data_parameters = '';
 
-		function __construct($contents) {
-		  $this->tableBlock($contents);
+		function __construct() {
 		}
 
     function tableBlock($contents) {

--- a/admin/includes/classes/upload.php
+++ b/admin/includes/classes/upload.php
@@ -13,7 +13,7 @@
   class upload {
     var $file, $filename, $destination, $permissions, $extensions, $tmp_filename, $message_location;
 
-    function upload($file = '', $destination = '', $permissions = '777', $extensions = '') {
+    function __construct($file = '', $destination = '', $permissions = '777', $extensions = '') {
       $this->set_file($file);
       $this->set_destination($destination);
       $this->set_permissions($permissions);


### PR DESCRIPTION
## php7 admin/classes Changes and Testing

### General approach to changes:
Rename constructor from class name function to __construct.
Files where approach was varied:
- object_info.php
- payment_module_info.php
- rss.php
- shopping_cart.php
- table_block.php

### General testing approach:
- before change, set to php7 and confirm deprecated notice appears
- confirm change removes notice
- check page behaviour before and after change is the same
- if it couldn't be executed by running core code, I didn't change it

action_recorder.php
- extends [catalog/] actionRecorder
- dynamically instantiates modules but only method call is setIdentifier
- used once in admin only to instantiate, no use of class name method
- rename constructor
- test in login.php

box.php
- extends tableBlock
- no instances of ->box found in admin
- rename constructor
- tested in banner manager

cfg_modules.php
- no direct calls of class name method found in admin
- rename constructor
- class dynamically instantiates modules - but doesn't dynamically call class name methods
- test in module admin

currencies.php
- no direct calls of class name method found in admin
- rename constructor
- test in orders and currencies

email.php
- no direct calls of class name method found in admin
- rename constructor
- test in mail

language.php
- no direct calls of class name method found in admin
- rename constructor
- test by setting get language

logger.php
- no direct calls of class name method found in admin
- rename constructor
- test by turning on logging

message_stack.php
- extends tableBlock
- no instances of ->messageStack found in admin
- rename constructor
- tested in banner manager

mime.php
- no direct calls of class name method found in admin
- rename constructor
- test in mail (instantiated for any type of email content sent)

object_info.php
- class name method is both setter and resetter
- several instances of ->objectInfo found in admin
- __construct added calling existing constructor
- tested in banner manager

order.php
- no direct calls of class name method found in admin
- rename constructor
- test in invoice, orders and packing slip

passwordhash.php
- no instances of ->PasswordHash found in admin
- constructor renamed
- test in login (for tep_validate_password) and administrators (for tep_encrypt_password), including with htaccess

payment_module_info.php
- can't find any use of this file
- class name different to file name so unlikely to be included/instantiated dynamically
- no change to contents but could remove file (??)
- tested by visiting payment modules (installed and to install), orders

phplot.php
- no instances of ->PHPlot found in admin
- constructor renamed
- tested in countries

rss.php
- no constructor defined
- no change
- test in dashboard/latest news + latest addons

shopping_cart.php
- constructor only resets object, designed to be called as a reset method too
- but it isn't!!
- empty __construct added; existing constructor left (just in case)
- tested in whos_online

split_page_results.php
- no instances of ->splitPageResults found in admin
- constructor renamed
- tested in countries

table_block.php
- never instantiated directly, only via child classes
- so doesn't need constructor, which has no means of testing
- class name method called by children so can't be renamed
- no change
- [maybe add __construct calling class name method in case instantiated in addons?]
- testing by watching for deprecated notice for this module while testing others throughout admin

upload.php
- no instances of ->upload found in admin
- constructor renamed
- tested in banner manager
