### PR TITLE
split page results class update

### DIFF
--- a/admin/includes/classes/split_page_results.php
+++ b/admin/includes/classes/split_page_results.php
@@ -38,7 +38,7 @@
       $sql_query .= " limit " . max($offset, 0) . ", " . $max_rows_per_page;
     }
 
-    function display_links($query_numrows, $max_rows_per_page, $max_page_links, $current_page_number, $parameters = '', $page_name = 'page') {
+    function display_links($query_numrows, $max_rows_per_page, $max_page_links, $current_page_number, $parameters = '', $page_name = 'page', $anchor='') {
       global $PHP_SELF;
 
       if ( tep_not_null($parameters) && (substr($parameters, -1) != '&') ) $parameters .= '&';
@@ -55,7 +55,7 @@
         $display_links = tep_draw_form('pages', $PHP_SELF, '', 'get');
 
         if ($current_page_number > 1) {
-          $display_links .= '<a href="' . tep_href_link($PHP_SELF, $parameters . $page_name . '=' . ($current_page_number - 1)) . '" class="splitPageLink">' . PREVNEXT_BUTTON_PREV . '</a>&nbsp;&nbsp;';
+          $display_links .= '<a href="' . tep_href_link($PHP_SELF, $parameters . $page_name . '=' . ($current_page_number - 1)) . $anchor . '" class="splitPageLink">' . PREVNEXT_BUTTON_PREV . '</a>&nbsp;&nbsp;';
         } else {
           $display_links .= PREVNEXT_BUTTON_PREV . '&nbsp;&nbsp;';
         }
@@ -63,7 +63,7 @@
         $display_links .= sprintf(TEXT_RESULT_PAGE, tep_draw_pull_down_menu($page_name, $pages_array, $current_page_number, 'onchange="this.form.submit();"'), $num_pages);
 
         if (($current_page_number < $num_pages) && ($num_pages != 1)) {
-          $display_links .= '&nbsp;&nbsp;<a href="' . tep_href_link($PHP_SELF, $parameters . $page_name . '=' . ($current_page_number + 1)) . '" class="splitPageLink">' . PREVNEXT_BUTTON_NEXT . '</a>';
+          $display_links .= '&nbsp;&nbsp;<a href="' . tep_href_link($PHP_SELF, $parameters . $page_name . '=' . ($current_page_number + 1)) . $anchor . '" class="splitPageLink">' . PREVNEXT_BUTTON_NEXT . '</a>';
         } else {
           $display_links .= '&nbsp;&nbsp;' . PREVNEXT_BUTTON_NEXT;
         }


### PR DESCRIPTION
This adds an "anchor" argument to retain current tab on page load when
page results are inside a jquery ui tab. Otherwise, when the pager is pressed the page reloads with the first tab focused.

Sample usage:
display_links($query_numrows, $max_rows_per_page, $max_page_links,
$current_page_number, $parameters = '', $page_name = 'page',
**"#section_products_options"**);

where **"#section_products_options"** is the anchor that defines current
tab.