### PR TITLE
php 7 admin/modules changes - class name method is no longer constructor

### DIFF
--- a/admin/includes/modules/cfg_modules/cfgm_action_recorder.php
+++ b/admin/includes/modules/cfg_modules/cfgm_action_recorder.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = false;
 
-    function cfgm_action_recorder() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'action_recorder/';
       $this->title = MODULE_CFG_MODULE_ACTION_RECORDER_TITLE;
     }

--- a/admin/includes/modules/cfg_modules/cfgm_boxes.php
+++ b/admin/includes/modules/cfg_modules/cfgm_boxes.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = true;
 
-    function cfgm_boxes() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'boxes/';
       $this->title = MODULE_CFG_MODULE_BOXES_TITLE;
     }

--- a/admin/includes/modules/cfg_modules/cfgm_dashboard.php
+++ b/admin/includes/modules/cfg_modules/cfgm_dashboard.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = false;
 
-    function cfgm_dashboard() {
+    function __construct() {
       $this->directory = DIR_FS_ADMIN . 'includes/modules/dashboard/';
       $this->language_directory = DIR_FS_ADMIN . 'includes/languages/';
       $this->title = MODULE_CFG_MODULE_DASHBOARD_TITLE;

--- a/admin/includes/modules/cfg_modules/cfgm_header_tags.php
+++ b/admin/includes/modules/cfg_modules/cfgm_header_tags.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = true;
 
-    function cfgm_header_tags() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'header_tags/';
       $this->title = MODULE_CFG_MODULE_HEADER_TAGS_TITLE;
     }

--- a/admin/includes/modules/cfg_modules/cfgm_navbar_modules.php
+++ b/admin/includes/modules/cfg_modules/cfgm_navbar_modules.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = false;
 
-    function cfgm_navbar_modules() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'navbar_modules/';
       $this->title = MODULE_CFG_MODULE_CONTENT_NAVBAR_TITLE;
     }

--- a/admin/includes/modules/cfg_modules/cfgm_order_total.php
+++ b/admin/includes/modules/cfg_modules/cfgm_order_total.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = false;
 
-    function cfgm_order_total() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'order_total/';
       $this->title = MODULE_CFG_MODULE_ORDER_TOTAL_TITLE;
     }

--- a/admin/includes/modules/cfg_modules/cfgm_payment.php
+++ b/admin/includes/modules/cfg_modules/cfgm_payment.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = false;
 
-    function cfgm_payment() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'payment/';
       $this->title = MODULE_CFG_MODULE_PAYMENT_TITLE;
     }

--- a/admin/includes/modules/cfg_modules/cfgm_shipping.php
+++ b/admin/includes/modules/cfg_modules/cfgm_shipping.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = false;
 
-    function cfgm_shipping() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'shipping/';
       $this->title = MODULE_CFG_MODULE_SHIPPING_TITLE;
     }

--- a/admin/includes/modules/cfg_modules/cfgm_social_bookmarks.php
+++ b/admin/includes/modules/cfg_modules/cfgm_social_bookmarks.php
@@ -18,7 +18,7 @@
     var $title;
     var $template_integration = false;
 
-    function cfgm_social_bookmarks() {
+    function __construct() {
       $this->directory = DIR_FS_CATALOG_MODULES . 'social_bookmarks/';
       $this->title = MODULE_CFG_MODULE_SOCIAL_BOOKMARKS_TITLE;
     }

--- a/admin/includes/modules/dashboard/d_admin_logins.php
+++ b/admin/includes/modules/dashboard/d_admin_logins.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_admin_logins() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_ADMIN_LOGINS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_ADMIN_LOGINS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_customers.php
+++ b/admin/includes/modules/dashboard/d_customers.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_customers() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_CUSTOMERS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_CUSTOMERS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_latest_addons.php
+++ b/admin/includes/modules/dashboard/d_latest_addons.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_latest_addons() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_LATEST_ADDONS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_LATEST_ADDONS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_latest_news.php
+++ b/admin/includes/modules/dashboard/d_latest_news.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_latest_news() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_LATEST_NEWS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_LATEST_NEWS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_orders.php
+++ b/admin/includes/modules/dashboard/d_orders.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_orders() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_ORDERS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_ORDERS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_partner_news.php
+++ b/admin/includes/modules/dashboard/d_partner_news.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_partner_news() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_PARTNER_NEWS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_PARTNER_NEWS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_reviews.php
+++ b/admin/includes/modules/dashboard/d_reviews.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_reviews() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_REVIEWS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_REVIEWS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_security_checks.php
+++ b/admin/includes/modules/dashboard/d_security_checks.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_security_checks() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_SECURITY_CHECKS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_SECURITY_CHECKS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_total_customers.php
+++ b/admin/includes/modules/dashboard/d_total_customers.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_total_customers() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_TOTAL_CUSTOMERS_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_TOTAL_CUSTOMERS_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_total_revenue.php
+++ b/admin/includes/modules/dashboard/d_total_revenue.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_total_revenue() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_TOTAL_REVENUE_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_TOTAL_REVENUE_DESCRIPTION;
 

--- a/admin/includes/modules/dashboard/d_version_check.php
+++ b/admin/includes/modules/dashboard/d_version_check.php
@@ -17,7 +17,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function d_version_check() {
+    function __construct() {
       $this->title = MODULE_ADMIN_DASHBOARD_VERSION_CHECK_TITLE;
       $this->description = MODULE_ADMIN_DASHBOARD_VERSION_CHECK_DESCRIPTION;
 

--- a/admin/includes/modules/newsletters/newsletter.php
+++ b/admin/includes/modules/newsletters/newsletter.php
@@ -13,7 +13,7 @@
   class newsletter {
     var $show_choose_audience, $title, $content;
 
-    function newsletter($title, $content) {
+    function __construct($title, $content) {
       $this->show_choose_audience = false;
       $this->title = $title;
       $this->content = $content;

--- a/admin/includes/modules/newsletters/product_notification.php
+++ b/admin/includes/modules/newsletters/product_notification.php
@@ -13,7 +13,7 @@
   class product_notification {
     var $show_choose_audience, $title, $content;
 
-    function product_notification($title, $content) {
+    function __construct($title, $content) {
       $this->show_choose_audience = true;
       $this->title = $title;
       $this->content = $content;

--- a/admin/includes/modules/security_check/config_file_catalog.php
+++ b/admin/includes/modules/security_check/config_file_catalog.php
@@ -13,7 +13,7 @@
   class securityCheck_config_file_catalog {
     var $type = 'warning';
 
-    function securityCheck_config_file_catalog() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/config_file_catalog.php');

--- a/admin/includes/modules/security_check/default_currency.php
+++ b/admin/includes/modules/security_check/default_currency.php
@@ -13,7 +13,7 @@
   class securityCheck_default_currency {
     var $type = 'error';
 
-    function securityCheck_default_currency() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/default_currency.php');

--- a/admin/includes/modules/security_check/default_language.php
+++ b/admin/includes/modules/security_check/default_language.php
@@ -13,7 +13,7 @@
   class securityCheck_default_language {
     var $type = 'error';
 
-    function securityCheck_default_language() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/default_language.php');

--- a/admin/includes/modules/security_check/download_directory.php
+++ b/admin/includes/modules/security_check/download_directory.php
@@ -13,7 +13,7 @@
   class securityCheck_download_directory {
     var $type = 'warning';
 
-    function securityCheck_download_directory() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/download_directory.php');

--- a/admin/includes/modules/security_check/extended/admin_backup_directory_listing.php
+++ b/admin/includes/modules/security_check/extended/admin_backup_directory_listing.php
@@ -14,7 +14,7 @@
     var $type = 'error';
     var $has_doc = true;
 
-    function securityCheckExtended_admin_backup_directory_listing() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/extended/admin_backup_directory_listing.php');

--- a/admin/includes/modules/security_check/extended/admin_backup_file.php
+++ b/admin/includes/modules/security_check/extended/admin_backup_file.php
@@ -14,7 +14,7 @@
     var $type = 'error';
     var $has_doc = true;
 
-    function securityCheckExtended_admin_backup_file() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/extended/admin_backup_file.php');

--- a/admin/includes/modules/security_check/extended/admin_http_authentication.php
+++ b/admin/includes/modules/security_check/extended/admin_http_authentication.php
@@ -13,7 +13,7 @@
   class securityCheckExtended_admin_http_authentication {
     var $type = 'warning';
 
-    function securityCheckExtended_admin_http_authentication() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/extended/admin_http_authentication.php');

--- a/admin/includes/modules/security_check/extended/ext_directory_listing.php
+++ b/admin/includes/modules/security_check/extended/ext_directory_listing.php
@@ -14,7 +14,7 @@
     var $type = 'warning';
     var $has_doc = true;
 
-    function securityCheckExtended_ext_directory_listing() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/extended/ext_directory_listing.php');

--- a/admin/includes/modules/security_check/extended/mysql_utf8.php
+++ b/admin/includes/modules/security_check/extended/mysql_utf8.php
@@ -14,7 +14,7 @@
     var $type = 'warning';
     var $has_doc = true;
 
-    function securityCheckExtended_mysql_utf8() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/extended/mysql_utf8.php');

--- a/admin/includes/modules/security_check/extended/version_check.php
+++ b/admin/includes/modules/security_check/extended/version_check.php
@@ -14,7 +14,7 @@
     var $type = 'warning';
     var $has_doc = true;
 
-    function securityCheckExtended_version_check() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/extended/version_check.php');

--- a/admin/includes/modules/security_check/extended_last_run.php
+++ b/admin/includes/modules/security_check/extended_last_run.php
@@ -13,7 +13,7 @@
   class securityCheck_extended_last_run {
     var $type = 'warning';
 
-    function securityCheck_extended_last_run() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/extended_last_run.php');

--- a/admin/includes/modules/security_check/file_uploads.php
+++ b/admin/includes/modules/security_check/file_uploads.php
@@ -13,7 +13,7 @@
   class securityCheck_file_uploads {
     var $type = 'warning';
 
-    function securityCheck_file_uploads() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/file_uploads.php');

--- a/admin/includes/modules/security_check/install_directory.php
+++ b/admin/includes/modules/security_check/install_directory.php
@@ -13,7 +13,7 @@
   class securityCheck_install_directory {
     var $type = 'warning';
 
-    function securityCheck_install_directory() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/install_directory.php');

--- a/admin/includes/modules/security_check/session_auto_start.php
+++ b/admin/includes/modules/security_check/session_auto_start.php
@@ -13,7 +13,7 @@
   class securityCheck_session_auto_start {
     var $type = 'warning';
 
-    function securityCheck_session_auto_start() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/session_auto_start.php');

--- a/admin/includes/modules/security_check/session_storage.php
+++ b/admin/includes/modules/security_check/session_storage.php
@@ -13,7 +13,7 @@
   class securityCheck_session_storage {
     var $type = 'warning';
 
-    function securityCheck_session_storage() {
+    function __construct() {
       global $language;
 
       include(DIR_FS_ADMIN . 'includes/languages/' . $language . '/modules/security_check/session_storage.php');

--- a/admin/security_checks.php
+++ b/admin/security_checks.php
@@ -76,8 +76,7 @@
 
 <?php
   foreach ($modules as $module) {
-    $tmpclass = $module['class'];
-    $secCheck = $$tmpclass;
+    $secCheck = ${$module['class']};
 
     if ( !in_array($secCheck->type, $types) ) {
       $secCheck->type = 'info';

--- a/admin/security_checks.php
+++ b/admin/security_checks.php
@@ -76,7 +76,8 @@
 
 <?php
   foreach ($modules as $module) {
-    $secCheck = $$module['class'];
+    $tmpclass = $module['class'];
+    $secCheck = $$tmpclass;
 
     if ( !in_array($secCheck->type, $types) ) {
       $secCheck->type = 'info';


### PR DESCRIPTION
This set of changes were straightforward in the classes themselves - rename constructor approach was suitable in each case.

The only anomaly was that one piece of syntax in admin/security_checks.php didn't work any longer (possibly a php 7 bug?) and required a small workaround.

Dashboard modules tested in modules and dashboard.
Config modules tested in modules.
Security modules tested in security checks and dashboard
Newsletter modules tested in newsletter