### PR TITLE
undefined filename error in paypal express

### DIFF
--- a/includes/modules/payment/paypal_express.php
+++ b/includes/modules/payment/paypal_express.php
@@ -696,7 +696,7 @@
       $dialog_error = MODULE_PAYMENT_PAYPAL_EXPRESS_DIALOG_CONNECTION_ERROR;
       $dialog_connection_time = MODULE_PAYMENT_PAYPAL_EXPRESS_DIALOG_CONNECTION_TIME;
 
-      $test_url = tep_href_link(FILENAME_MODULES, 'set=payment&module=' . $this->code . '&action=install&subaction=conntest');
+      $test_url = tep_href_link('modules.php', 'set=payment&module=' . $this->code . '&action=install&subaction=conntest');
 
       $js = <<<EOD
 <script>


### PR DESCRIPTION
Problem:
When paypal express checkout module is installed and configured,
in [catalog]/shopping_cart.php and [catalog]/checkout_payment.php the following error shows:
Use of undefined constant FILENAME_MODULES - assumed 'FILENAME_MODULES' in ***********includes\modules\payment\paypal_express.php on line 699
Conditions:
php 5.6 or  php 7.0 with error reporting  in application_top.php set to "error_reporting(E_ALL);"

Error may show also on checkout_confirmation.php if returned from PayPal
to confirm order.

Reason:
constant FILENAME_MODULES is defined only in Admin, not in Catalog filenames.php

Suggested fix: 
hardcode filename instead of filename constant.
in: [catalog]/includes/modules/payment/paypal_express.php line 699
Change: FILENAME_MODULES to 'modules.php' 