### PR TITLE
php 7 shop payment modules

### DIFF
--- a/includes/modules/payment/authorizenet_cc_aim.php
+++ b/includes/modules/payment/authorizenet_cc_aim.php
@@ -13,7 +13,7 @@
   class authorizenet_cc_aim {
     var $code, $title, $description, $enabled;
 
-    function authorizenet_cc_aim() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'authorizenet|authorizenet_cc_aim|2.0|2.3';

--- a/includes/modules/payment/authorizenet_cc_dpm.php
+++ b/includes/modules/payment/authorizenet_cc_dpm.php
@@ -13,7 +13,7 @@
   class authorizenet_cc_dpm {
     var $code, $title, $description, $enabled;
 
-    function authorizenet_cc_dpm() {
+    function __construct() {
       global $order;
 
       $this->signature = 'authorizenet|authorizenet_cc_dpm|1.0|2.3';

--- a/includes/modules/payment/authorizenet_cc_sim.php
+++ b/includes/modules/payment/authorizenet_cc_sim.php
@@ -13,7 +13,7 @@
   class authorizenet_cc_sim {
     var $code, $title, $description, $enabled;
 
-    function authorizenet_cc_sim() {
+    function __construct() {
       global $order;
 
       $this->signature = 'authorizenet|authorizenet_cc_sim|2.0|2.3';

--- a/includes/modules/payment/braintree_cc.php
+++ b/includes/modules/payment/braintree_cc.php
@@ -13,7 +13,7 @@
   class braintree_cc {
     var $code, $title, $description, $enabled;
 
-    function braintree_cc() {
+    function __construct() {
       global $order;
 
       $this->signature = 'braintree|braintree_cc|1.1|2.3';

--- a/includes/modules/payment/chronopay.php
+++ b/includes/modules/payment/chronopay.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function chronopay() {
+    function __construct() {
       global $order;
 
       $this->signature = 'chronopay|chronopay|1.0|2.2';

--- a/includes/modules/payment/cod.php
+++ b/includes/modules/payment/cod.php
@@ -13,7 +13,7 @@
   class cod {
     var $code, $title, $description, $enabled;
 
-    function cod() {
+    function __construct() {
       global $order;
 
       $this->code = 'cod';

--- a/includes/modules/payment/inpay.php
+++ b/includes/modules/payment/inpay.php
@@ -14,7 +14,7 @@ class inpay
     var $code, $title, $description, $enabled;
 
     // class constructor
-    function inpay()
+    function __construct()
     {
         global $order;
         $this->signature = 'inpay|inpay|1.0|2.2';

--- a/includes/modules/payment/ipayment_cc.php
+++ b/includes/modules/payment/ipayment_cc.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function ipayment_cc() {
+    function __construct() {
       global $order;
 
       $this->signature = 'ipayment|ipayment_cc|1.1|2.2';

--- a/includes/modules/payment/ipayment_elv.php
+++ b/includes/modules/payment/ipayment_elv.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function ipayment_elv() {
+    function __construct() {
       global $order;
 
       $this->signature = 'ipayment|ipayment_elv|1.0|2.2';

--- a/includes/modules/payment/ipayment_pp.php
+++ b/includes/modules/payment/ipayment_pp.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function ipayment_pp() {
+    function __construct() {
       global $order;
 
       $this->signature = 'ipayment|ipayment_pp|1.0|2.2';

--- a/includes/modules/payment/moneybookers.php
+++ b/includes/modules/payment/moneybookers.php
@@ -19,7 +19,7 @@
     var $_payment_method_image = 'by_ewallet_90x45.gif';
 
 // class constructor
-    function moneybookers() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers|1.0|2.3';

--- a/includes/modules/payment/moneybookers_acc.php
+++ b/includes/modules/payment/moneybookers_acc.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'All_CCs_225x45.gif';
 
 // class constructor
-    function moneybookers_acc() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_acc|1.0|2.3';

--- a/includes/modules/payment/moneybookers_bwi.php
+++ b/includes/modules/payment/moneybookers_bwi.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = '';
 
 // class constructor
-    function moneybookers_bwi() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_bwi|1.0|2.3';

--- a/includes/modules/payment/moneybookers_csi.php
+++ b/includes/modules/payment/moneybookers_csi.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'cartasi.gif';
 
 // class constructor
-    function moneybookers_csi() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_csi|1.0|2.3';

--- a/includes/modules/payment/moneybookers_did.php
+++ b/includes/modules/payment/moneybookers_did.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'ec.gif';
 
 // class constructor
-    function moneybookers_did() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_did|1.0|2.3';

--- a/includes/modules/payment/moneybookers_dnk.php
+++ b/includes/modules/payment/moneybookers_dnk.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'dankort.gif';
 
 // class constructor
-    function moneybookers_dnk() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_dnk|1.0|2.3';

--- a/includes/modules/payment/moneybookers_ebt.php
+++ b/includes/modules/payment/moneybookers_ebt.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'nordea.gif';
 
 // class constructor
-    function moneybookers_ebt() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_ebt|1.0|2.3';

--- a/includes/modules/payment/moneybookers_ent.php
+++ b/includes/modules/payment/moneybookers_ent.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'enets.gif';
 
 // class constructor
-    function moneybookers_ent() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_ent|1.0|2.3';

--- a/includes/modules/payment/moneybookers_gcb.php
+++ b/includes/modules/payment/moneybookers_gcb.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'cartebleue.gif';
 
 // class constructor
-    function moneybookers_gcb() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_gcb|1.0|2.3';

--- a/includes/modules/payment/moneybookers_gir.php
+++ b/includes/modules/payment/moneybookers_gir.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'giropay.gif';
 
 // class constructor
-    function moneybookers_gir() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_gir|1.0|2.3';

--- a/includes/modules/payment/moneybookers_idl.php
+++ b/includes/modules/payment/moneybookers_idl.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'ideal.gif';
 
 // class constructor
-    function moneybookers_idl() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_idl|1.0|2.3';

--- a/includes/modules/payment/moneybookers_lsr.php
+++ b/includes/modules/payment/moneybookers_lsr.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'laser.gif';
 
 // class constructor
-    function moneybookers_lsr() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_lsr|1.0|2.3';

--- a/includes/modules/payment/moneybookers_mae.php
+++ b/includes/modules/payment/moneybookers_mae.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'maestro.gif';
 
 // class constructor
-    function moneybookers_mae() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_mae|1.0|2.3';

--- a/includes/modules/payment/moneybookers_msc.php
+++ b/includes/modules/payment/moneybookers_msc.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = '4b.gif';
 
 // class constructor
-    function moneybookers_msc() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_msc|1.0|2.3';

--- a/includes/modules/payment/moneybookers_ngp.php
+++ b/includes/modules/payment/moneybookers_ngp.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = '';
 
 // class constructor
-    function moneybookers_ngp() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_ngp|1.0|2.3';

--- a/includes/modules/payment/moneybookers_npy.php
+++ b/includes/modules/payment/moneybookers_npy.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'eps.gif';
 
 // class constructor
-    function moneybookers_npy() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_npy|1.0|2.3';

--- a/includes/modules/payment/moneybookers_pli.php
+++ b/includes/modules/payment/moneybookers_pli.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'poli.gif';
 
 // class constructor
-    function moneybookers_pli() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_pli|1.0|2.3';

--- a/includes/modules/payment/moneybookers_psp.php
+++ b/includes/modules/payment/moneybookers_psp.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'postepay.gif';
 
 // class constructor
-    function moneybookers_psp() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_psp|1.0|2.3';

--- a/includes/modules/payment/moneybookers_pwy.php
+++ b/includes/modules/payment/moneybookers_pwy.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'p24.gif';
 
 // class constructor
-    function moneybookers_pwy() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_pwy|1.0|2.3';

--- a/includes/modules/payment/moneybookers_sft.php
+++ b/includes/modules/payment/moneybookers_sft.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'sofort.gif';
 
 // class constructor
-    function moneybookers_sft() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_sft|1.0|2.3';

--- a/includes/modules/payment/moneybookers_slo.php
+++ b/includes/modules/payment/moneybookers_slo.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'solo.gif';
 
 // class constructor
-    function moneybookers_slo() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_slo|1.0|2.3';

--- a/includes/modules/payment/moneybookers_so2.php
+++ b/includes/modules/payment/moneybookers_so2.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'nordea.gif';
 
 // class constructor
-    function moneybookers_so2() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_so2|1.0|2.3';

--- a/includes/modules/payment/moneybookers_vsa.php
+++ b/includes/modules/payment/moneybookers_vsa.php
@@ -23,7 +23,7 @@
     var $_payment_method_image = 'euro6000.gif';
 
 // class constructor
-    function moneybookers_vsa() {
+    function __construct() {
       global $order;
 
       $this->signature = 'moneybookers|moneybookers_vsa|1.0|2.3';

--- a/includes/modules/payment/moneyorder.php
+++ b/includes/modules/payment/moneyorder.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function moneyorder() {
+    function __construct() {
       global $order;
 
       $this->code = 'moneyorder';

--- a/includes/modules/payment/nochex.php
+++ b/includes/modules/payment/nochex.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function nochex() {
+    function __construct() {
       global $order;
 
       $this->code = 'nochex';

--- a/includes/modules/payment/paypal_express.php
+++ b/includes/modules/payment/paypal_express.php
@@ -13,7 +13,7 @@
   class paypal_express {
     var $code, $title, $description, $enabled;
 
-    function paypal_express() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order, $payment;
 
       $this->signature = 'paypal|paypal_express|3.0|2.3';

--- a/includes/modules/payment/paypal_pro_dp.php
+++ b/includes/modules/payment/paypal_pro_dp.php
@@ -13,7 +13,7 @@
   class paypal_pro_dp {
     var $code, $title, $description, $enabled;
 
-    function paypal_pro_dp() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'paypal|paypal_pro_dp|3.0|2.3';

--- a/includes/modules/payment/paypal_pro_hs.php
+++ b/includes/modules/payment/paypal_pro_hs.php
@@ -13,7 +13,7 @@
   class paypal_pro_hs {
     var $code, $title, $description, $enabled;
 
-    function paypal_pro_hs() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'paypal|paypal_pro_hs|1.0|2.3';

--- a/includes/modules/payment/paypal_pro_payflow_dp.php
+++ b/includes/modules/payment/paypal_pro_payflow_dp.php
@@ -13,7 +13,7 @@
   class paypal_pro_payflow_dp {
     var $code, $title, $description, $enabled;
 
-    function paypal_pro_payflow_dp() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'paypal|paypal_pro_payflow_dp|3.0|2.3';

--- a/includes/modules/payment/paypal_pro_payflow_ec.php
+++ b/includes/modules/payment/paypal_pro_payflow_ec.php
@@ -13,7 +13,7 @@
   class paypal_pro_payflow_ec {
     var $code, $title, $description, $enabled;
 
-    function paypal_pro_payflow_ec() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'paypal|paypal_pro_payflow_ec|3.0|2.3';

--- a/includes/modules/payment/paypal_standard.php
+++ b/includes/modules/payment/paypal_standard.php
@@ -13,7 +13,7 @@
   class paypal_standard {
     var $code, $title, $description, $enabled;
 
-    function paypal_standard() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'paypal|paypal_standard|3.1|2.3';

--- a/includes/modules/payment/paypoint_secpay.php
+++ b/includes/modules/payment/paypoint_secpay.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function paypoint_secpay() {
+    function __construct() {
       global $order;
 
       $this->signature = 'paypoint|paypoint_secpay|1.0|2.3';

--- a/includes/modules/payment/pm2checkout.php
+++ b/includes/modules/payment/pm2checkout.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function pm2checkout() {
+    function __construct() {
       global $order;
 
       $this->signature = '2checkout|pm2checkout|1.2|2.2';

--- a/includes/modules/payment/psigate.php
+++ b/includes/modules/payment/psigate.php
@@ -14,7 +14,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function psigate() {
+    function __construct() {
       global $order;
 
       $this->code = 'psigate';

--- a/includes/modules/payment/rbsworldpay_hosted.php
+++ b/includes/modules/payment/rbsworldpay_hosted.php
@@ -13,7 +13,7 @@
   class rbsworldpay_hosted {
     var $code, $title, $description, $enabled;
 
-    function rbsworldpay_hosted() {
+    function __construct() {
       global $order;
 
       $this->signature = 'rbs|worldpay_hosted|2.0|2.3';

--- a/includes/modules/payment/sage_pay_direct.php
+++ b/includes/modules/payment/sage_pay_direct.php
@@ -13,7 +13,7 @@
   class sage_pay_direct {
     var $code, $title, $description, $enabled;
 
-    function sage_pay_direct() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'sage_pay|sage_pay_direct|3.0|2.3';

--- a/includes/modules/payment/sage_pay_form.php
+++ b/includes/modules/payment/sage_pay_form.php
@@ -13,7 +13,7 @@
   class sage_pay_form {
     var $code, $title, $description, $enabled;
 
-    function sage_pay_form() {
+    function __construct() {
       global $order;
 
       $this->signature = 'sage_pay|sage_pay_form|2.0|2.3';

--- a/includes/modules/payment/sage_pay_server.php
+++ b/includes/modules/payment/sage_pay_server.php
@@ -13,7 +13,7 @@
   class sage_pay_server {
     var $code, $title, $description, $enabled;
 
-    function sage_pay_server() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order;
 
       $this->signature = 'sage_pay|sage_pay_server|2.0|2.3';

--- a/includes/modules/payment/sofortueberweisung_direct.php
+++ b/includes/modules/payment/sofortueberweisung_direct.php
@@ -15,7 +15,7 @@
     var $code, $title, $description, $enabled;
 
 // class constructor
-    function sofortueberweisung_direct() {
+    function __construct() {
       global $order;
 
       $this->code = 'sofortueberweisung_direct';

--- a/includes/modules/payment/stripe.php
+++ b/includes/modules/payment/stripe.php
@@ -13,7 +13,7 @@
   class stripe {
     var $code, $title, $description, $enabled;
 
-    function stripe() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF, $order, $payment;
 
       $this->signature = 'stripe|stripe|1.0|2.3';


### PR DESCRIPTION
## php7 modules payment Changes and Testing

### General approach to changes:
Rename constructor from class name function to __construct.

I don't think payment handling and admin use dynamically - pick a module that's easy to test and take it all the way through an admin and order cycle from installation to completed checkout to confirm. 

Files where approach was varied:
- none (except where already compliant!)

### General testing approach:
- use modules/payment page [MP]
- before change, set to php7 and confirm deprecated notice appears [*] 
- confirm change removes notice [+]
-- first 3 carried out for all modules
- check module installs ok [=]
-- not possible for moneybookers without valid login
- check payment page after change [-]
-- not possible for many modules without valid login

authorizenet_cc_aim.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

authorizenet_cc_dpm.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

authorizenet_cc_sim.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

braintree_cc.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

braintree_cc folder and subfolders
(need to check globals & static use)
- php5 constructors
- functions declared static when so used
- no global keywords

chronopay.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

cod.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

inpay.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

ipayment_cc.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

ipayment_elv.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

ipayment_pp.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

moneybookers.php [MP*+]
- php4 constructor
- not hard-coded anywhere
- rename

all of the following:
- extends moneybookers
- php4 constructor
- not hard-coded anywhere
- rename

-moneybookers_acc.php [MP*+]
-moneybookers_bwi.php [MP*+]
-moneybookers_csi.php [MP*+]
-moneybookers_did.php [MP*+]
-moneybookers_dnk.php [MP*+]
-moneybookers_ebt.php [MP*+]
-moneybookers_ent.php [MP*+]
-moneybookers_gcb.php [MP*+]
-moneybookers_gir.php [MP*+]
-moneybookers_idl.php [MP*+]
-moneybookers_lsr.php [MP*+]
-moneybookers_mae.php [MP*+]
-moneybookers_msc.php [MP*+]
-moneybookers_ngp.php [MP*+]
-moneybookers_npy.php [MP*+]
-moneybookers_pli.php [MP*+]
-moneybookers_psp.php [MP*+]
-moneybookers_pwy.php [MP*+]
-moneybookers_sft.php [MP*+]
-moneybookers_slo.php [MP*+]
-moneybookers_so2.php [MP*+]
-moneybookers_vsa.php [MP*+]

moneyorder.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

nochex.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

paypal_express.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

paypal_pro_dp.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

paypal_pro_hs.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

paypal_pro_payflow_dp.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

paypal_pro_payflow_ec.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

paypal_standard.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

paypoint_secpay.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

pm2checkout.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

psigate.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

rbsworldpay_hosted.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

sage_pay_direct.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

sage_pay_form.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

sage_pay_server.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename

sofortueberweisung_direct.php [MP*+=-]
- php4 constructor
- not hard-coded anywhere
- rename

stripe.php [MP*+=]
- php4 constructor
- not hard-coded anywhere
- rename
