### PR TITLE
 tep_info_image fix for SSL catalog

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -269,7 +269,11 @@
 
   function tep_info_image($image, $alt, $width = '', $height = '') {
     if (tep_not_null($image) && (file_exists(DIR_FS_CATALOG_IMAGES . $image)) ) {
-      $image = tep_image(HTTP_CATALOG_SERVER . DIR_WS_CATALOG_IMAGES . $image, $alt, $width, $height);
+      if (ENABLE_SSL_CATALOG == 'true') {
+        $image = tep_image(HTTPS_CATALOG_SERVER . DIR_WS_CATALOG_IMAGES . $image, $alt, $width, $height);
+      } else {
+        $image = tep_image(HTTP_CATALOG_SERVER . DIR_WS_CATALOG_IMAGES . $image, $alt, $width, $height);
+      }
     } else {
       $image = TEXT_IMAGE_NONEXISTENT;
     }


### PR DESCRIPTION
tep_info_image: This function adds non-secure images to categories.php. Modified so it checks first if ENABLE_SSL_CATALOG is set to true so it outputs correct SSL images.
