### PR TITLE
php7 - eponymous methods no longer class constructors - content modules

### DIFF
--- a/includes/modules/content/account/cm_account_braintree_cards.php
+++ b/includes/modules/content/account/cm_account_braintree_cards.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_account_braintree_cards() {
+    function __construct() {
       global $language;
 
       $this->code = get_class($this);

--- a/includes/modules/content/account/cm_account_sage_pay_cards.php
+++ b/includes/modules/content/account/cm_account_sage_pay_cards.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_account_sage_pay_cards() {
+    function __construct() {
       global $language;
 
       $this->code = get_class($this);

--- a/includes/modules/content/account/cm_account_set_password.php
+++ b/includes/modules/content/account/cm_account_set_password.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_account_set_password() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/account/cm_account_stripe_cards.php
+++ b/includes/modules/content/account/cm_account_stripe_cards.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_account_stripe_cards() {
+    function __construct() {
       global $language;
 
       $this->code = get_class($this);

--- a/includes/modules/content/checkout_success/cm_cs_downloads.php
+++ b/includes/modules/content/checkout_success/cm_cs_downloads.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_cs_downloads() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/checkout_success/cm_cs_product_notifications.php
+++ b/includes/modules/content/checkout_success/cm_cs_product_notifications.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_cs_product_notifications() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/checkout_success/cm_cs_redirect_old_order.php
+++ b/includes/modules/content/checkout_success/cm_cs_redirect_old_order.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_cs_redirect_old_order() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/checkout_success/cm_cs_thank_you.php
+++ b/includes/modules/content/checkout_success/cm_cs_thank_you.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_cs_thank_you() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/footer/cm_footer_account.php
+++ b/includes/modules/content/footer/cm_footer_account.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_footer_account() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/footer/cm_footer_contact_us.php
+++ b/includes/modules/content/footer/cm_footer_contact_us.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_footer_contact_us() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/footer/cm_footer_information_links.php
+++ b/includes/modules/content/footer/cm_footer_information_links.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_footer_information_links() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/footer/cm_footer_text.php
+++ b/includes/modules/content/footer/cm_footer_text.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_footer_text() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/footer_suffix/cm_footer_extra_copyright.php
+++ b/includes/modules/content/footer_suffix/cm_footer_extra_copyright.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_footer_extra_copyright() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/footer_suffix/cm_footer_extra_icons.php
+++ b/includes/modules/content/footer_suffix/cm_footer_extra_icons.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_footer_extra_icons() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/header/cm_header_breadcrumb.php
+++ b/includes/modules/content/header/cm_header_breadcrumb.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_header_breadcrumb() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/header/cm_header_buttons.php
+++ b/includes/modules/content/header/cm_header_buttons.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_header_buttons() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/header/cm_header_logo.php
+++ b/includes/modules/content/header/cm_header_logo.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_header_logo() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/header/cm_header_messagestack.php
+++ b/includes/modules/content/header/cm_header_messagestack.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_header_messagestack() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/header/cm_header_search.php
+++ b/includes/modules/content/header/cm_header_search.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_header_search() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/login/cm_create_account_link.php
+++ b/includes/modules/content/login/cm_create_account_link.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_create_account_link() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/login/cm_login_form.php
+++ b/includes/modules/content/login/cm_login_form.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_login_form() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/login/cm_paypal_login.php
+++ b/includes/modules/content/login/cm_paypal_login.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_paypal_login() {
+    function __construct() {
       global $HTTP_GET_VARS, $PHP_SELF;
 
       $this->signature = 'paypal|paypal_login|1.0|2.3';

--- a/includes/modules/content/navigation/cm_navbar.php
+++ b/includes/modules/content/navigation/cm_navbar.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_navbar() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/product_info/cm_pi_gtin.php
+++ b/includes/modules/content/product_info/cm_pi_gtin.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_pi_gtin() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 

--- a/includes/modules/content/product_info/cm_pi_reviews.php
+++ b/includes/modules/content/product_info/cm_pi_reviews.php
@@ -18,7 +18,7 @@
     var $sort_order;
     var $enabled = false;
 
-    function cm_pi_reviews() {
+    function __construct() {
       $this->code = get_class($this);
       $this->group = basename(dirname(__FILE__));
 


### PR DESCRIPTION
All catalog content modules except index and index nested which are already compliant

### General approach to changes:
Rename constructor from class name function to __construct.
Files where approach was varied:

cm_i_ ... already compliant
cm_in_ ... already compliant

### General testing approach:
- before change, set to php7 and confirm deprecated notice appears
- confirm change removes notice
- check page behaviour before and after change is the same