### PR TITLE
remove include filenames.php from admin application_top

### DIFF
--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -47,9 +47,6 @@
   define('LOCAL_EXE_ZIP', 'zip');
   define('LOCAL_EXE_UNZIP', 'unzip');
 
-// include the list of project filenames
-  require(DIR_WS_INCLUDES . 'filenames.php');
-
 // include the list of project database tables
   require(DIR_WS_INCLUDES . 'database_tables.php');
 


### PR DESCRIPTION
Include still seems to be there (but the file isn't)...

...or did you mean to leave an empty file for the sake of old addons?

Either way, it doesn't work as it stands.