### PR TITLE
Forgotten fifth parameter

### DIFF
--- a/product_reviews.php
+++ b/product_reviews.php
@@ -75,7 +75,7 @@ echo '<div class="col-sm-8 text-center alert alert-success" itemprop="AggregateR
   <div class="col-sm-4 text-center">
     <?php echo '<a href="' . tep_href_link('product_info.php', 'products_id=' . $product_info['products_id']) . '">' . tep_image('images/' . $product_info['products_image'], addslashes($product_info['products_name']), SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT, 'hspace="5" vspace="5"') . '</a>'; ?>
 
-    <p><?php echo tep_draw_button(IMAGE_BUTTON_IN_CART, 'fa fa-shopping-cart', tep_href_link($PHP_SELF, tep_get_all_get_params(array('action')) . 'action=buy_now'), null, 'btn-success btn-reviews btn-buy'); ?></p>
+    <p><?php echo tep_draw_button(IMAGE_BUTTON_IN_CART, 'fa fa-shopping-cart', tep_href_link($PHP_SELF, tep_get_all_get_params(array('action')) . 'action=buy_now'), null, null, 'btn-success btn-reviews btn-buy'); ?></p>
   </div>
   
   <div class="clearfix"></div>


### PR DESCRIPTION
Fifth parameter on [tep_draw_function](https://github.com/gburton/Responsive-osCommerce/blob/master/includes/functions/html_output.php#L344) must be an array.

```
Warning:  Illegal string offset 'type' in includes/functions/html_output.php on line 397
Stack trace:
    1. {main}() product_reviews.php:0
    2. tep_draw_button($title = *uninitialized*, $icon = *uninitialized*, $link = *uninitialized*, $priority = *uninitialized*, $params = *uninitialized*, $style = *uninitialized*) product_reviews.php:78
```