### PR TITLE
$cPath_array must be initializated

### DIFF
--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -216,6 +216,8 @@
   } else {
     $cPath = '';
   }
+  
+  $cPath_array = array();
 
   if (tep_not_null($cPath)) {
     $cPath_array = tep_parse_category_path($cPath);


### PR DESCRIPTION
Several files call like this:
`(sizeof($cPath_array) > 0) `
Example: [admin/categories.php](https://github.com/gburton/Responsive-osCommerce/blob/master/admin/categories.php#L976)
...therefore $cPath_array must be initializated