### PR TITLE
Bugfix: WorldPay Hosted Payments - check query overwriting orders class - rename check object

### DIFF
--- a/includes/modules/payment/rbsworldpay_hosted.php
+++ b/includes/modules/payment/rbsworldpay_hosted.php
@@ -349,11 +349,11 @@
         tep_redirect(tep_href_link('shopping_cart.php'));
       }
 
-      $order = tep_db_fetch_array($order_query);
+      $db_order = tep_db_fetch_array($order_query);
 
       $order_status_id = (MODULE_PAYMENT_RBSWORLDPAY_HOSTED_ORDER_STATUS_ID > 0 ? (int)MODULE_PAYMENT_RBSWORLDPAY_HOSTED_ORDER_STATUS_ID : (int)DEFAULT_ORDERS_STATUS_ID);
 
-      if ($order['orders_status'] == MODULE_PAYMENT_RBSWORLDPAY_HOSTED_PREPARE_ORDER_STATUS_ID) {
+      if ($db_order['orders_status'] == MODULE_PAYMENT_RBSWORLDPAY_HOSTED_PREPARE_ORDER_STATUS_ID) {
         tep_db_query("update " . TABLE_ORDERS . " set orders_status = '" . $order_status_id . "', last_modified = now() where orders_id = '" . (int)$order_id . "'");
 
         $sql_data_array = array('orders_id' => $order_id,


### PR DESCRIPTION
Bug.

Symptoms: empty list of products in order email and stock not getting updated

Cause: check query on order status in before process was overwriting the orders class, with knock-ons through the rest of it.

Fix: rename result of query to something other than $order