### PR TITLE
missing tag in admin orders.php

### DIFF
--- a/admin/orders.php
+++ b/admin/orders.php
@@ -355,6 +355,7 @@ if ( typeof jQuery.ui == 'undefined' ) {
         <td><?php echo ENTRY_NOTIFY_CUSTOMER; ?></td>
         <td><?php echo tep_draw_checkbox_field('notify', '', true); ?></td>
       </tr>
+      <tr>
         <td><?php echo ENTRY_NOTIFY_COMMENTS; ?></td>
         <td><?php echo tep_draw_checkbox_field('notify_comments', '', true); ?></td>
       </tr>


### PR DESCRIPTION
Not earth-shattering. Browsers can work out what's going on anyway. Likely a core bug in any case. Ignore or merge as you like!