### PR TITLE
Reduce database requests by using original class "category_tree"

### DIFF
--- a/includes/modules/content/index_nested/cm_in_title.php
+++ b/includes/modules/content/index_nested/cm_in_title.php
@@ -37,8 +37,7 @@
       
       $content_width = MODULE_CONTENT_IN_TITLE_CONTENT_WIDTH;
      
-      $category_query = tep_db_query("select cd.categories_name, c.categories_image, cd.categories_description from categories c, categories_description cd where c.categories_id = '" . (int)$current_category_id . "' and cd.categories_id = '" . (int)$current_category_id . "' and cd.language_id = '" . (int)$languages_id . "'");
-      $category = tep_db_fetch_array($category_query);
+      $OSCOM_CategoryTree = new category_tree();
       
       ob_start();
       include('includes/modules/content/' . $this->group . '/templates/category_title.php');

--- a/includes/modules/content/index_nested/templates/category_title.php
+++ b/includes/modules/content/index_nested/templates/category_title.php
@@ -12,7 +12,7 @@
 ?>
 <div class="col-sm-<?php echo $content_width; ?> title index-nested-title">
   <div class="page-header">
-    <h1><?php echo sprintf(MODULE_CONTENT_IN_TITLE_PUBLIC_TITLE, $category['categories_name']); ?></h1>
+    <h1><?php echo sprintf(MODULE_CONTENT_IN_TITLE_PUBLIC_TITLE, $OSCOM_CategoryTree->getData($current_category_id, 'name')); ?></h1>
   </div>
 </div>
        


### PR DESCRIPTION
Optimizing base-code, decreasing multiple database requests for the same objects.
Why would request the database for something that is already requested and available to use?