### PR TITLE
suppress E_STRICT and simplify error_reporting setting

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -14,11 +14,7 @@
   define('PAGE_PARSE_START_TIME', microtime());
 
 // set the level of error reporting
-  error_reporting(E_ALL & ~E_NOTICE);
-  
-  if (defined('E_DEPRECATED')) {
-    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
-  }
+  error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 
 // check support for register_globals
   if (function_exists('ini_get') && (ini_get('register_globals') == false) && (PHP_VERSION < 4.3) ) {


### PR DESCRIPTION
New classes throw silly messages on php5 [see stackoverflow](https://stackoverflow.com/questions/41611058/why-does-php-allow-abstract-static-functions)
so don't include E_STRICT in error_reporting (it's not appropriate for production anyway)

and simplify the whole thing since E_DEPRECATED predates the minimum supported php version
