### PR TITLE
Fix for cart when removing items

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -230,6 +230,8 @@
         tep_db_query("delete from " . TABLE_CUSTOMERS_BASKET_ATTRIBUTES . " where customers_id = '" . (int)$customer_id . "' and products_id = '" . tep_db_input($products_id) . "'");
       }
 
+      $this->calculate();
+
 // assign a temporary unique ID to the order contents to prevent hack attempts during the checkout procedure
       $this->cartID = $this->generate_cart_id();
     }


### PR DESCRIPTION
Remembered this issue discussed here: https://forums.oscommerce.com/topic/410720-sessions-languages-and-ajax-loading/?do=findComment&comment=1752997
Would be good to add the fix to the final version. It re-calculates the cart when an item is removed to avoid $cart->total and $cart->weight show old values.