### PR TITLE
add pull down default to state menu

### DIFF
--- a/create_account.php
+++ b/create_account.php
@@ -414,7 +414,7 @@
         <?php
         if ($process == true) {
           if ($entry_state_has_zones == true) {
-            $zones_array = array();
+            $zones_array = array(array('id' => '', 'text' => PULL_DOWN_DEFAULT));                        
             $zones_query = tep_db_query("select zone_name from " . TABLE_ZONES . " where zone_country_id = '" . (int)$country . "' order by zone_name");
             while ($zones_values = tep_db_fetch_array($zones_query)) {
               $zones_array[] = array('id' => $zones_values['zone_name'], 'text' => $zones_values['zone_name']);

--- a/includes/modules/address_book_details.php
+++ b/includes/modules/address_book_details.php
@@ -135,7 +135,7 @@
           <?php
           if ($process == true) {
             if ($entry_state_has_zones == true) {
-              $zones_array = array();
+              $zones_array = array(array('id' => '', 'text' => PULL_DOWN_DEFAULT));                        
               $zones_query = tep_db_query("select zone_name from " . TABLE_ZONES . " where zone_country_id = '" . (int)$country . "' order by zone_name");
               while ($zones_values = tep_db_fetch_array($zones_query)) {
                 $zones_array[] = array('id' => $zones_values['zone_name'], 'text' => $zones_values['zone_name']);

--- a/includes/modules/checkout_new_address.php
+++ b/includes/modules/checkout_new_address.php
@@ -130,7 +130,7 @@
         <?php
         if ($process == true) {
           if ($entry_state_has_zones == true) {
-            $zones_array = array();
+            $zones_array = array(array('id' => '', 'text' => PULL_DOWN_DEFAULT));                        
             $zones_query = tep_db_query("select zone_name from " . TABLE_ZONES . " where zone_country_id = '" . (int)$country . "' order by zone_name");
             while ($zones_values = tep_db_fetch_array($zones_query)) {
               $zones_array[] = array('id' => $zones_values['zone_name'], 'text' => $zones_values['zone_name']);


### PR DESCRIPTION
Not a coding bug, but a functional error reported from a real store:

-     customer creates account
-     customer fills in a wrong state name which doesn't match any database state name
-     error is thrown "please select a state from the drop down menu"
-     the first alphabetic state is selected by default
-     customer doesn't pay attention and the first default state is submitted
-     solution: add "Please select" as default to the menu
