### PR TITLE
Fix warning message in admin->modules-> payment -> install module

### DIFF
--- a/includes/languages/english/modules/payment/moneyorder.php
+++ b/includes/languages/english/modules/payment/moneyorder.php
@@ -9,8 +9,14 @@
 
   Released under the GNU General Public License
 */
-
+  
   define('MODULE_PAYMENT_MONEYORDER_TEXT_TITLE', 'Check/Money Order');
-  define('MODULE_PAYMENT_MONEYORDER_TEXT_DESCRIPTION', 'Make Payable To:&nbsp;' . MODULE_PAYMENT_MONEYORDER_PAYTO . '<br /><br />Send To:<br />' . STORE_NAME . '<br />' . nl2br(STORE_ADDRESS) . '<br /><br />' . 'Your order will not ship until we receive payment.');
-  define('MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER', "Make Payable To: ". MODULE_PAYMENT_MONEYORDER_PAYTO . "\n\nSend To:\n" . STORE_NAME . "\n" . STORE_ADDRESS . "\n\n" . 'Your order will not ship until we receive payment.');
+  
+  if ( defined('MODULE_PAYMENT_MONEYORDER_STATUS') ) {
+    define('MODULE_PAYMENT_MONEYORDER_TEXT_DESCRIPTION', 'Make Payable To:&nbsp;' . MODULE_PAYMENT_MONEYORDER_PAYTO . '<br /><br />Send To:<br />' . STORE_NAME . '<br />' . nl2br(STORE_ADDRESS) . '<br /><br />' . 'Your order will not ship until we receive payment.');
+    define('MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER', "Make Payable To: ". MODULE_PAYMENT_MONEYORDER_PAYTO . "\n\nSend To:\n" . STORE_NAME . "\n" . STORE_ADDRESS . "\n\n" . 'Your order will not ship until we receive payment.');
+  } else {
+    define('MODULE_PAYMENT_MONEYORDER_TEXT_DESCRIPTION', 'Make Payable To:&nbsp;<br /><br />Send To:<br />' . STORE_NAME . '<br />' . nl2br(STORE_ADDRESS) . '<br /><br />' . 'Your order will not ship until we receive payment.');
+    define('MODULE_PAYMENT_MONEYORDER_TEXT_EMAIL_FOOTER', "Make Payable To: \n\nSend To:\n" . STORE_NAME . "\n" . STORE_ADDRESS . "\n\n" . 'Your order will not ship until we receive payment.');
+  }
 ?>


### PR DESCRIPTION

Warning: Use of undefined constant MODULE_PAYMENT_MONEYORDER_PAYTO - assumed 'MODULE_PAYMENT_MONEYORDER_PAYTO' (this will throw an Error in a future version of PHP)

The language file uses the constant MODULE_PAYMENT_MONEYORDER_PAYTO which is not defined until the module is installed.