### PR TITLE
fix continue button to submit button in checkout success

### DIFF
--- a/includes/modules/content/checkout_success/templates/tpl_cm_cs_continue_button.php
+++ b/includes/modules/content/checkout_success/templates/tpl_cm_cs_continue_button.php
@@ -1,7 +1,7 @@
 <div class="clearfix"></div>
 <div class="col-sm-<?php echo $content_width; ?> cm-cs-continue-button">
   <?php 
-  echo tep_draw_button(MODULE_CONTENT_CS_CONTINUE_BUTTON_TEXT, 'fas fa-thumbs-up', tep_href_link('index.php'), 'primary', null, 'btn-success btn-block btn-lg');
+  echo tep_draw_button(MODULE_CONTENT_CS_CONTINUE_BUTTON_TEXT, 'fas fa-thumbs-up', null, 'primary', null, 'btn-success btn-block btn-lg');
   ?>
 </div>
     


### PR DESCRIPTION
continue button must be form submit button.
see forum messages:
[https://forums.oscommerce.com/topic/398365-purchase-without-account-for-234-and-bs2334/?do=findComment&comment=1770093](url)