### PR TITLE
Update ht_product_schema.php

### DIFF
--- a/includes/modules/header_tags/ht_product_schema.php
+++ b/includes/modules/header_tags/ht_product_schema.php
@@ -98,7 +98,7 @@
           $average = tep_db_fetch_array($average_query);
           if ($average['count'] > 0) {
             $schema_product['aggregateRating'] = array("@type"       => "AggregateRating",
-                                                       "ratingValue" => (int)$average['average'],
+                                                       "ratingValue" => number_format($average['average'],2),
                                                        "reviewCount" => (int)$average['count']);
           }
           


### PR DESCRIPTION
Changine ratingValue to use number_format.  Reason is interger cast a 4.9 average to a 4.0 in testing using structured data tool.  Float makes an odd very long decimal.  number_format cast to preset decimals and seems to be best choice IMHO.