### PR TITLE
Proposal for stylsheet hook

### DIFF
--- a/includes/hooks/shop/siteWide/styleSheetUser.php
+++ b/includes/hooks/shop/siteWide/styleSheetUser.php
@@ -1,0 +1,29 @@
+<?php
+/*
+  Copyright (c) 2019, G Burton
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+class hook_shop_siteWide_styleSheetUser {
+  var $siteend = null;
+  var $version = '1.0.0'; 
+
+  
+  function listen_injectSiteEnd() {
+    $this->siteend .= '<!-- User manipulated stylsheet -->' . PHP_EOL;   
+    $this->siteend .= '<link href="user.css?v=' . $version .  '"" rel="stylesheet">' . PHP_EOL;
+
+    return $this->siteend;
+  }
+
+}

--- a/includes/hooks/shop/siteWide/styleSheets.php
+++ b/includes/hooks/shop/siteWide/styleSheets.php
@@ -16,7 +16,7 @@
 
 class hook_shop_siteWide_styleSheets {
   var $sitestart = null;
-  var $version = '1.0.0'; 
+  var $version = '1.0.0';
 
   
   function listen_injectSiteStart() {

--- a/includes/hooks/shop/siteWide/styleSheets.php
+++ b/includes/hooks/shop/siteWide/styleSheets.php
@@ -16,11 +16,12 @@
 
 class hook_shop_siteWide_styleSheets {
   var $sitestart = null;
+  var $version = '1.0.0'; 
+
   
   function listen_injectSiteStart() {
-    $this->sitestart .= '<!-- stylesheets hooked -->' . PHP_EOL;
-    $this->sitestart .= '<link href="custom.css" rel="stylesheet">' . PHP_EOL;
-    $this->sitestart .= '<link href="user.css" rel="stylesheet">' . PHP_EOL;
+    $this->sitestart .= '<!-- stylesheets hooked -->' . PHP_EOL;   
+    $this->sitestart .= '<link href="custom.css?v=' . $version .  '"" rel="stylesheet">' . PHP_EOL;
 
     return $this->sitestart;
   }


### PR DESCRIPTION
Proposal for stylesheet hooks

I had an issue with the user.css as it was not loaded as the last stylesheet. 
- That's why I want to _propose_ to either separate user.css and custom.css or the insert both of them at the end. In this way I want to ask 
- whether it was possible to _introduce a sort order_ for hooks in order to force the "system" to load them as intended. 
- Additionally when it comes to stylesheets the browser caches it all the time and troubleshooting can be a confusing when forgetting about this. That's why I integrated your version variable in the call directly which one can update when updating the file. In my case Page speed insights detected no change in the file as it was presumably cached already.